### PR TITLE
Fix/playback and client handling

### DIFF
--- a/src-tauri/src/api/innertube/core/clients.rs
+++ b/src-tauri/src/api/innertube/core/clients.rs
@@ -1,0 +1,338 @@
+//! Single source of truth for every InnerTube client identity Flow presents.
+//!
+//! Before this module the same client was declared in five places (the video
+//! context builders, the `post_innertube` User-Agent table, the music profiles,
+//! the SABR `ClientProfile`, and the media-proxy `MEDIA_UA_*` constants) and they
+//! had drifted: `ANDROID` was requested as `21.03.38` but its media bytes were
+//! fetched with a `19.29.37` User-Agent, `WEB_REMIX` was sent with its client *id*
+//! in the version field, and SABR reported a `WEB` version two years older than
+//! the one the extractor used. Every consumer now reads these definitions, so a
+//! version bump is a one-line edit that cannot leave a request half-updated.
+//!
+//! Mirrors `Prism_Mobile`'s `YouTubeClient.kt`, including its
+//! [`AttestationPlatform`] gate — see that type for why it is load-bearing.
+
+use serde_json::{Value, json};
+
+/// Signature timestamp sent in `playbackContext.contentPlaybackContext`.
+///
+/// Clients with `use_signature_timestamp` need one, and YouTube rotates the value
+/// with `player_ias` releases. Flow has no JS solver to read the live value out of
+/// `base.js`, so this is pinned; when signed clients start failing wholesale this
+/// is the first thing to re-check.
+pub const DEFAULT_SIGNATURE_TIMESTAMP: i64 = 19550;
+
+/// Which attestation runtime mints a PO token a given client's requests will be
+/// accepted with.
+///
+/// A PO token comes from BotGuard (web), DroidGuard (Android) or iOSGuard (iOS),
+/// and one platform's token is never valid on another's. Flow can only run
+/// BotGuard (`sidecar/integrity.cjs` and the hidden-WebView minter), so [`Web`] is
+/// the only family it can attest for. Encoding it here is what stops a BotGuard
+/// token being injected into an `IOS`/`ANDROID_VR` player request — a claim
+/// googlevideo validates and rejects, making it strictly worse than sending
+/// nothing.
+///
+/// [`Web`]: AttestationPlatform::Web
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AttestationPlatform {
+    /// BotGuard. The only runtime Flow owns.
+    Web,
+    /// DroidGuard, inside Google Play Services. Not reachable from a desktop app.
+    DroidGuard,
+    /// iOSGuard. Not reachable at all.
+    IosGuard,
+}
+
+/// One InnerTube client profile: everything needed to make a request look like
+/// that client, and the metadata that decides how it may be used.
+#[derive(Clone, Copy, Debug)]
+pub struct YouTubeClient {
+    pub name: &'static str,
+    /// Sent as `context.client.clientVersion` and `X-YouTube-Client-Version`.
+    pub version: &'static str,
+    /// Sent as `X-YouTube-Client-Name`, and as SABR's `streamer_context.client_name`.
+    pub client_id: &'static str,
+    pub user_agent: &'static str,
+    pub os_name: Option<&'static str>,
+    pub os_version: Option<&'static str>,
+    pub device_make: Option<&'static str>,
+    pub device_model: Option<&'static str>,
+    pub android_sdk_version: Option<&'static str>,
+    /// Whether the player request should carry a `signatureTimestamp`.
+    pub use_signature_timestamp: bool,
+    /// Embedded player: sends `thirdParty.embedUrl`, which bypasses age gating.
+    pub is_embedded: bool,
+    /// Whether a BotGuard token should be *requested* for this client. Distinct
+    /// from [`Self::attestation`], which says whether one would be *valid*: the
+    /// embedded TV player is web-family but is served fine without a token.
+    pub use_web_po_tokens: bool,
+    /// The runtime whose tokens this client's requests and URLs accept.
+    pub attestation: AttestationPlatform,
+}
+
+impl YouTubeClient {
+    /// Build the `context` object for this client.
+    ///
+    /// `gl` overrides the region for feeds that are region-scoped (the Shorts reel
+    /// sequence); everything else extracts against `US` so responses are
+    /// deterministic regardless of where the user is.
+    #[must_use]
+    pub fn context(&self, visitor_data: Option<&str>, gl: Option<&str>) -> Value {
+        let mut client = json!({
+            "clientName": self.name,
+            "clientVersion": self.version,
+            "hl": "en",
+            "gl": gl.unwrap_or("US"),
+            "utcOffsetMinutes": 0,
+        });
+        for (key, value) in [
+            ("osName", self.os_name),
+            ("osVersion", self.os_version),
+            ("deviceMake", self.device_make),
+            ("deviceModel", self.device_model),
+            ("androidSdkVersion", self.android_sdk_version),
+        ] {
+            if let Some(value) = value {
+                client[key] = json!(value);
+            }
+        }
+        if let Some(visitor) = visitor_data.filter(|value| !value.is_empty()) {
+            client["visitorData"] = json!(visitor);
+        }
+        json!({ "client": client })
+    }
+
+    /// The context for a player request, with the PO token attached only when this
+    /// client can actually be attested by the runtime Flow owns.
+    ///
+    /// Callers pass whatever token they hold and let this decide; that keeps the
+    /// attestation rule in one place instead of at every call site.
+    #[must_use]
+    pub fn player_context(
+        &self,
+        visitor_data: Option<&str>,
+        po_token: Option<&str>,
+        gl: Option<&str>,
+    ) -> Value {
+        let mut context = self.context(visitor_data, gl);
+        if !self.accepts_web_po_token() {
+            return context;
+        }
+        if let Some(token) = po_token.filter(|token| !token.is_empty()) {
+            context["serviceIntegrityDimensions"] = json!({ "poToken": token });
+        }
+        context
+    }
+
+    /// Whether a BotGuard-minted token is valid for this client.
+    #[must_use]
+    pub fn accepts_web_po_token(&self) -> bool {
+        matches!(self.attestation, AttestationPlatform::Web)
+    }
+
+    /// Numeric client id, for SABR's `streamer_context.client_name`.
+    #[must_use]
+    pub fn client_name_id(&self) -> i32 {
+        self.client_id.parse().unwrap_or(1)
+    }
+
+    #[must_use]
+    pub fn signature_timestamp(&self) -> Option<i64> {
+        self.use_signature_timestamp
+            .then_some(DEFAULT_SIGNATURE_TIMESTAMP)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client definitions
+// ---------------------------------------------------------------------------
+
+const USER_AGENT_WEB: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+/// The primary direct-URL client for both video and music.
+///
+/// googlevideo serves its formats without a PO token and without an `n`
+/// parameter, so it reaches first frame with neither an attestation nor an nsig
+/// decode — the two properties `ANDROID_VR` was chosen for and lost when YouTube
+/// began requiring a GVS PO token for it (yt-dlp #17261, Aug 2026).
+///
+/// Version-sensitive: the older `0.1`/`RealityDevice14,1` build still answers but
+/// serves a stub ladder (17 formats, one audio track) where this build serves the
+/// full one. Do not "simplify" these values.
+pub const VISIONOS: YouTubeClient = YouTubeClient {
+    name: "VISIONOS",
+    version: "1.02",
+    client_id: "101",
+    user_agent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.0 Safari/605.1.15",
+    os_name: Some("visionOS"),
+    os_version: Some("26.5.23O471"),
+    device_make: Some("Apple"),
+    device_model: Some("RealityDevice17,1"),
+    android_sdk_version: None,
+    use_signature_timestamp: false,
+    is_embedded: false,
+    use_web_po_tokens: false,
+    attestation: AttestationPlatform::IosGuard,
+};
+
+pub const ANDROID_VR: YouTubeClient = YouTubeClient {
+    name: "ANDROID_VR",
+    version: "1.61.48",
+    client_id: "28",
+    user_agent: "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
+    os_name: Some("Android"),
+    os_version: Some("12"),
+    device_make: Some("Oculus"),
+    device_model: Some("Quest 3"),
+    android_sdk_version: Some("32"),
+    use_signature_timestamp: false,
+    is_embedded: false,
+    use_web_po_tokens: false,
+    attestation: AttestationPlatform::DroidGuard,
+};
+
+/// Non-ABR VR build — the smoothest for music, which is why it leads the audio
+/// chain ahead of the newer ones.
+pub const ANDROID_VR_1_43_32: YouTubeClient = YouTubeClient {
+    version: "1.43.32",
+    user_agent: "com.google.android.apps.youtube.vr.oculus/1.43.32 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/107.0.5284.2)",
+    ..ANDROID_VR
+};
+
+/// Same build as [`ANDROID_VR`] with the Oculus-prefixed device string. YouTube
+/// answers the two differently often enough that it is kept as its own retry.
+pub const ANDROID_VR_NO_AUTH: YouTubeClient = YouTubeClient {
+    user_agent: "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Oculus Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
+    ..ANDROID_VR
+};
+
+pub const ANDROID: YouTubeClient = YouTubeClient {
+    name: "ANDROID",
+    version: "21.03.38",
+    client_id: "3",
+    user_agent: "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip",
+    os_name: Some("Android"),
+    os_version: Some("14"),
+    device_make: Some("Google"),
+    device_model: Some("Pixel 6 Pro"),
+    android_sdk_version: Some("34"),
+    use_signature_timestamp: true,
+    is_embedded: false,
+    use_web_po_tokens: false,
+    attestation: AttestationPlatform::DroidGuard,
+};
+
+pub const ANDROID_CREATOR: YouTubeClient = YouTubeClient {
+    name: "ANDROID_CREATOR",
+    version: "25.03.101",
+    client_id: "14",
+    user_agent: "com.google.android.apps.youtube.creator/25.03.101 (Linux; U; Android 15; en_US; Pixel 9 Pro Fold; Build/AP3A.241005.015.A2; Cronet/132.0.6779.0)",
+    os_name: Some("Android"),
+    os_version: Some("15"),
+    device_make: Some("Google"),
+    device_model: Some("Pixel 9 Pro Fold"),
+    android_sdk_version: Some("35"),
+    use_signature_timestamp: true,
+    is_embedded: false,
+    use_web_po_tokens: false,
+    attestation: AttestationPlatform::DroidGuard,
+};
+
+pub const IOS: YouTubeClient = YouTubeClient {
+    name: "IOS",
+    version: "19.29.1",
+    client_id: "5",
+    user_agent: "com.google.ios.youtube/19.29.1 (iPhone14,5; U; CPU iOS 17_5_1 like Mac OS X; en_US)",
+    os_name: Some("iOS"),
+    os_version: Some("17.5.1"),
+    device_make: Some("Apple"),
+    device_model: Some("iPhone14,5"),
+    android_sdk_version: None,
+    use_signature_timestamp: true,
+    is_embedded: false,
+    use_web_po_tokens: false,
+    attestation: AttestationPlatform::IosGuard,
+};
+
+pub const IPADOS: YouTubeClient = YouTubeClient {
+    version: "21.03.3",
+    user_agent: "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)",
+    os_name: Some("iPadOS"),
+    os_version: Some("17.7.10.21H450"),
+    device_model: Some("iPad7,6"),
+    ..IOS
+};
+
+pub const WEB: YouTubeClient = YouTubeClient {
+    name: "WEB",
+    version: "2.20260120.01.00",
+    client_id: "1",
+    user_agent: USER_AGENT_WEB,
+    os_name: Some("Windows"),
+    os_version: Some("10.0"),
+    device_make: None,
+    device_model: None,
+    android_sdk_version: None,
+    use_signature_timestamp: true,
+    is_embedded: false,
+    use_web_po_tokens: true,
+    attestation: AttestationPlatform::Web,
+};
+
+pub const WEB_REMIX: YouTubeClient = YouTubeClient {
+    name: "WEB_REMIX",
+    version: "1.20260213.01.00",
+    client_id: "67",
+    os_name: None,
+    os_version: None,
+    ..WEB
+};
+
+/// Charts backend (`charts.youtube.com`). Metadata only — it serves no streams.
+pub const WEB_MUSIC_ANALYTICS: YouTubeClient = YouTubeClient {
+    name: "WEB_MUSIC_ANALYTICS",
+    version: "2.0",
+    client_id: "31",
+    use_signature_timestamp: false,
+    use_web_po_tokens: false,
+    ..WEB_REMIX
+};
+
+/// Embedded TV player — the age-restriction bypass, kept last in every chain.
+pub const TVHTML5_SIMPLY_EMBEDDED_PLAYER: YouTubeClient = YouTubeClient {
+    name: "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
+    version: "2.0",
+    client_id: "85",
+    user_agent: "Mozilla/5.0 (PlayStation; PlayStation 4/12.02) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15",
+    os_name: None,
+    os_version: None,
+    is_embedded: true,
+    use_web_po_tokens: false,
+    ..WEB
+};
+
+/// Every client the registry knows, for reverse lookup by name.
+const ALL: &[YouTubeClient] = &[
+    VISIONOS,
+    ANDROID_VR,
+    ANDROID,
+    ANDROID_CREATOR,
+    IOS,
+    IPADOS,
+    WEB,
+    WEB_REMIX,
+    WEB_MUSIC_ANALYTICS,
+    TVHTML5_SIMPLY_EMBEDDED_PLAYER,
+];
+
+/// Resolve a client by its InnerTube `clientName`.
+///
+/// Where several builds share a name (the VR ones) this returns the canonical
+/// one, which is all the callers that key off a `c=` URL parameter need — the
+/// name is the only thing such a URL carries.
+#[must_use]
+pub fn by_name(name: &str) -> Option<&'static YouTubeClient> {
+    ALL.iter()
+        .find(|client| client.name.eq_ignore_ascii_case(name))
+}

--- a/src-tauri/src/api/innertube/core/context.rs
+++ b/src-tauri/src/api/innertube/core/context.rs
@@ -1,112 +1,5 @@
 use crate::api::innertube::InnertubeClient;
-use serde_json::Value;
-
-pub fn get_ios_context(visitor_data: Option<String>, po_token: Option<String>) -> Value {
-    let mut client = serde_json::json!({
-        "clientName": "IOS",
-        "clientVersion": "19.29.1",
-        "hl": "en",
-        "gl": "US",
-        "utcOffsetMinutes": 0,
-        "deviceMake": "Apple",
-        "deviceModel": "iPhone14,5",
-        "osName": "iOS",
-        "osVersion": "17.5.1"
-    });
-
-    if let Some(vd) = visitor_data {
-        client["visitorData"] = Value::String(vd);
-    }
-
-    let mut context = serde_json::json!({
-        "client": client,
-    });
-
-    if let Some(token) = po_token {
-        context["serviceIntegrityDimensions"] = serde_json::json!({
-            "poToken": token
-        });
-    }
-
-    context
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-pub fn get_ipados_context(visitor_data: Option<String>, po_token: Option<String>) -> Value {
-    let mut client = serde_json::json!({
-        "clientName": "IOS",
-        "clientVersion": "21.03.3",
-        "hl": "en",
-        "gl": "US",
-        "utcOffsetMinutes": 0,
-        "deviceMake": "Apple",
-        "deviceModel": "iPad7,6",
-        "osName": "iPadOS",
-        "osVersion": "17.7.10.21H450"
-    });
-
-    if let Some(vd) = visitor_data {
-        client["visitorData"] = Value::String(vd);
-    }
-
-    let mut context = serde_json::json!({
-        "client": client,
-    });
-
-    if let Some(token) = po_token {
-        context["serviceIntegrityDimensions"] = serde_json::json!({
-            "poToken": token
-        });
-    }
-
-    context
-}
-
-pub fn get_android_vr_context(visitor_data: Option<String>) -> Value {
-    let mut client = serde_json::json!({
-        "clientName": "ANDROID_VR",
-        "clientVersion": "1.61.48",
-        "hl": "en",
-        "gl": "US",
-        "utcOffsetMinutes": 0,
-        "deviceMake": "Oculus",
-        "deviceModel": "Quest 3",
-        "osName": "Android",
-        "osVersion": "12",
-        "androidSdkVersion": "32"
-    });
-
-    if let Some(vd) = visitor_data {
-        client["visitorData"] = Value::String(vd);
-    }
-
-    serde_json::json!({
-        "client": client,
-    })
-}
-
-pub fn get_android_context(visitor_data: Option<String>) -> Value {
-    let mut client = serde_json::json!({
-        "clientName": "ANDROID",
-        "clientVersion": "21.03.38",
-        "hl": "en",
-        "gl": "US",
-        "utcOffsetMinutes": 0,
-        "deviceMake": "Google",
-        "deviceModel": "Pixel 6 Pro",
-        "osName": "Android",
-        "osVersion": "14",
-        "androidSdkVersion": "34"
-    });
-
-    if let Some(vd) = visitor_data {
-        client["visitorData"] = Value::String(vd);
-    }
-
-    serde_json::json!({
-        "client": client,
-    })
-}
+use crate::api::innertube::core::clients;
 
 impl InnertubeClient {
     pub async fn fetch_visitor_data(&self) -> Option<String> {
@@ -118,7 +11,7 @@ impl InnertubeClient {
 
         let mut payload = serde_json::json!({});
         if let Ok(res) = self
-            .post_innertube("visitor_id", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("visitor_id", &clients::WEB, &mut payload)
             .await
         {
             if let Some(vd) = res["responseContext"]["visitorData"].as_str() {

--- a/src-tauri/src/api/innertube/core/http.rs
+++ b/src-tauri/src/api/innertube/core/http.rs
@@ -1,24 +1,10 @@
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients::{self, YouTubeClient};
 use crate::errors::{AppError, AppResult};
 use serde_json::Value;
 
-pub fn get_client_id(client_name: &str) -> &'static str {
-    match client_name {
-        "WEB" => "1",
-        "WEB_REMIX" => "67",
-        "WEB_CREATOR" => "62",
-        "TVHTML5" => "7",
-        "TVHTML5_SIMPLY_EMBEDDED_PLAYER" => "85",
-        "IOS" => "5",
-        "ANDROID" => "3",
-        "ANDROID_VR" => "28",
-        "ANDROID_CREATOR" => "14",
-        "VISIONOS" => "101",
-        _ => "1",
-    }
-}
-
-#[allow(dead_code)]
+/// Percent-encode for InnerTube query strings, which want `+` for spaces rather
+/// than the `%20` a general-purpose encoder emits.
 pub fn custom_url_encode(s: &str) -> String {
     let mut encoded = String::new();
     for b in s.as_bytes() {
@@ -26,58 +12,28 @@ pub fn custom_url_encode(s: &str) -> String {
             b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
                 encoded.push(*b as char);
             }
-            b' ' => {
-                encoded.push('+');
-            }
-            _ => {
-                encoded.push_str(&format!("%{:02X}", b));
-            }
+            b' ' => encoded.push('+'),
+            _ => encoded.push_str(&format!("%{:02X}", b)),
         }
     }
     encoded
 }
 
 impl InnertubeClient {
+    /// POST to the main-site InnerTube API as `client`.
+    ///
+    /// The client's User-Agent, numeric id and version all come from the one
+    /// registry entry, so a request can never claim to be one build in its
+    /// context and another in its headers.
     pub async fn post_innertube(
         &self,
         endpoint: &str,
-        client_name: &str,
-        client_version: &str,
+        client: &YouTubeClient,
         payload: &mut Value,
     ) -> AppResult<Value> {
-        let user_agent = match (client_name, client_version) {
-            ("IOS", "21.03.3") => {
-                "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)"
-            }
-            ("IOS", _) => {
-                "com.google.ios.youtube/19.29.1 (iPhone14,5; U; CPU iOS 17_5_1 like Mac OS X; en_US)"
-            }
-            ("ANDROID_VR", _) => {
-                "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)"
-            }
-            ("ANDROID", "21.03.38") => {
-                "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip"
-            }
-            _ => {
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-            }
-        };
-
         if let Some(obj) = payload.as_object_mut() {
-            if !obj.contains_key("context") {
-                obj.insert(
-                    "context".to_string(),
-                    serde_json::json!({
-                        "client": {
-                            "clientName": client_name,
-                            "clientVersion": client_version,
-                            "hl": "en",
-                            "gl": "US",
-                            "utcOffsetMinutes": 0
-                        }
-                    }),
-                );
-            }
+            obj.entry("context")
+                .or_insert_with(|| client.context(None, None));
         }
 
         let mut custom_referer = None;
@@ -93,14 +49,12 @@ impl InnertubeClient {
             "https://www.youtube.com/youtubei/v1/{}?prettyPrint=false",
             endpoint
         );
-        let client_id = get_client_id(client_name);
-
         let mut req = self
             .client
             .post(&url)
-            .header(reqwest::header::USER_AGENT, user_agent)
-            .header("X-YouTube-Client-Name", client_id)
-            .header("X-YouTube-Client-Version", client_version)
+            .header(reqwest::header::USER_AGENT, client.user_agent)
+            .header("X-YouTube-Client-Name", client.client_id)
+            .header("X-YouTube-Client-Version", client.version)
             .header("Origin", "https://www.youtube.com")
             .header("Cookie", "SOCS=CAE=") // Bypasses cookie consent blocks!
             .json(payload);
@@ -150,7 +104,7 @@ impl InnertubeClient {
         });
 
         let res = self
-            .post_innertube("next", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("next", &clients::WEB_REMIX, &mut payload)
             .await?;
 
         let lyrics_tab = res["contents"]["singleColumnMusicWatchNextResultsRenderer"]

--- a/src-tauri/src/api/innertube/core/mod.rs
+++ b/src-tauri/src/api/innertube/core/mod.rs
@@ -1,4 +1,5 @@
 pub mod botguard;
+pub mod clients;
 pub mod context;
 pub mod http;
 pub mod utils;

--- a/src-tauri/src/api/innertube/extractors/channel.rs
+++ b/src-tauri/src/api/innertube/extractors/channel.rs
@@ -1,4 +1,5 @@
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     detect_lockup_is_live, detect_video_is_live, extract_channel_id_from_video_renderer,
     normalize_youtube_image_url, parse_duration_seconds, parse_mixed_number_word_to_long,
@@ -1046,7 +1047,7 @@ impl InnertubeClient {
         });
 
         let res = self
-            .post_innertube("browse", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("browse", &clients::WEB, &mut payload)
             .await?;
 
         debug!(
@@ -1335,7 +1336,7 @@ impl InnertubeClient {
         };
 
         let res = self
-            .post_innertube("browse", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("browse", &clients::WEB, &mut payload)
             .await?;
         let (items, next_page_token, sort_latest_token, sort_popular_token, sort_oldest_token) =
             extract_videos_from_browse(&res);

--- a/src-tauri/src/api/innertube/extractors/comments.rs
+++ b/src-tauri/src/api/innertube/extractors/comments.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use tracing::debug;
 
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     extract_text_from_value, parse_mixed_number_word_to_long, thumbnail_url_from_array,
 };
@@ -525,7 +526,7 @@ impl InnertubeClient {
         debug!(video_id = %video_id_trimmed, has_page_token = page_token.is_some(), "[get_comments] Starting comments fetch");
 
         let res = self
-            .post_innertube("next", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("next", &clients::WEB, &mut payload)
             .await?;
         let mut comments_res = parse_comments_json(&res);
 
@@ -552,7 +553,7 @@ impl InnertubeClient {
                     "continuation": token
                 });
                 let next_res = self
-                    .post_innertube("next", "WEB", "2.20260120.01.00", &mut next_payload)
+                    .post_innertube("next", &clients::WEB, &mut next_payload)
                     .await?;
                 comments_res = parse_comments_json(&next_res);
                 if comments_res.comment_count_text.is_none() {
@@ -584,7 +585,7 @@ impl InnertubeClient {
             let mut payload = serde_json::json!({
                 "continuation": token
             });
-            self.post_innertube("browse", "WEB", "2.20260120.01.00", &mut payload)
+            self.post_innertube("browse", &clients::WEB, &mut payload)
                 .await?
         } else {
             let mut payload = serde_json::json!({
@@ -595,7 +596,7 @@ impl InnertubeClient {
             } else {
                 payload["canonicalBaseUrl"] = serde_json::json!(format!("/post/{post_id_trimmed}"));
             }
-            self.post_innertube("browse", "WEB", "2.20260120.01.00", &mut payload)
+            self.post_innertube("browse", &clients::WEB, &mut payload)
                 .await?
         };
 
@@ -611,7 +612,7 @@ impl InnertubeClient {
                     "continuation": token
                 });
                 let next_res = self
-                    .post_innertube("browse", "WEB", "2.20260120.01.00", &mut next_payload)
+                    .post_innertube("browse", &clients::WEB, &mut next_payload)
                     .await?;
                 comments_res = parse_comments_json(&next_res);
                 if comments_res.comment_count_text.is_none() {

--- a/src-tauri/src/api/innertube/extractors/live_chat.rs
+++ b/src-tauri/src/api/innertube/extractors/live_chat.rs
@@ -2,10 +2,10 @@ use serde_json::Value;
 use tracing::debug;
 
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::errors::AppResult;
 use crate::models::live_chat::{LiveChatMessage, LiveChatResponse, LiveChatSegment};
 
-const CLIENT_VERSION: &str = "2.20260120.01.00";
 const DEFAULT_POLL_MS: u64 = 2000;
 const MIN_POLL_MS: u64 = 1000;
 const MAX_POLL_MS: u64 = 6000;
@@ -200,7 +200,7 @@ impl InnertubeClient {
     async fn get_live_chat_seed(&self, video_id: &str) -> AppResult<(Option<String>, bool)> {
         let mut payload = serde_json::json!({ "videoId": video_id });
         let res = self
-            .post_innertube("next", "WEB", CLIENT_VERSION, &mut payload)
+            .post_innertube("next", &clients::WEB, &mut payload)
             .await?;
         Ok((extract_seed_continuation(&res), extract_is_replay(&res)))
     }
@@ -233,12 +233,7 @@ impl InnertubeClient {
 
         let mut payload = serde_json::json!({ "continuation": token });
         let res = self
-            .post_innertube(
-                "live_chat/get_live_chat",
-                "WEB",
-                CLIENT_VERSION,
-                &mut payload,
-            )
+            .post_innertube("live_chat/get_live_chat", &clients::WEB, &mut payload)
             .await?;
         let (messages, next, polling_interval_ms) = parse_live_chat_page(&res);
 

--- a/src-tauri/src/api/innertube/extractors/music.rs
+++ b/src-tauri/src/api/innertube/extractors/music.rs
@@ -1,6 +1,7 @@
 use tracing::debug;
 
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     extract_channel_id_from_music_renderer, map_related_content_to_video_summary,
     parse_duration_seconds,
@@ -41,7 +42,7 @@ impl InnertubeClient {
         }
 
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
 
         let mut lyrics_text = String::new();
@@ -122,7 +123,7 @@ impl InnertubeClient {
         }
 
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
 
         let mut related_items = Vec::new();
@@ -230,7 +231,7 @@ impl InnertubeClient {
         });
 
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
         let tracks = parse_music_album_json(&res);
 
@@ -242,7 +243,7 @@ impl InnertubeClient {
             "browseId": "FEmusic_home"
         });
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
 
         // 1. Parse chips
@@ -477,7 +478,7 @@ impl InnertubeClient {
             "browseId": artist_browse_id
         });
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
         let mut artist_page = parse_music_artist_json(&res)?;
         artist_page.artist.id = artist_browse_id.to_string();
@@ -489,7 +490,7 @@ impl InnertubeClient {
             "browseId": "FEmusic_explore"
         });
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
         parse_music_explore_json(&res)
     }
@@ -506,7 +507,7 @@ impl InnertubeClient {
             })
         };
         let res = self
-            .post_innertube("browse", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("browse", &clients::WEB_REMIX, &mut payload)
             .await?;
         parse_music_charts_json(&res)
     }

--- a/src-tauri/src/api/innertube/extractors/player.rs
+++ b/src-tauri/src/api/innertube/extractors/player.rs
@@ -1,8 +1,6 @@
 use crate::api::innertube::InnertubeClient;
 use crate::api::innertube::core::botguard::generate_po_token;
-use crate::api::innertube::core::context::{
-    get_android_context, get_android_vr_context, get_ios_context,
-};
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     collect_related_content_items, dedupe_related_content_items,
     extract_channel_id_from_video_renderer, extract_text_from_value, thumbnail_url_from_array,
@@ -19,15 +17,45 @@ use serde_json::Value;
 use std::collections::{HashMap, HashSet};
 use tracing::{debug, info, warn};
 
-const ANDROID_VR_USER_AGENT: &str = "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)";
-const ANDROID_USER_AGENT: &str = "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip";
-const IOS_USER_AGENT: &str =
-    "com.google.ios.youtube/19.29.1 (iPhone14,5; U; CPU iOS 17_5_1 like Mac OS X; en_US)";
-// Only referenced by the SABR live smoke test below.
-#[cfg(test)]
-const IPADOS_USER_AGENT: &str =
-    "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)";
-const WEB_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+/// How long any single client gets before the ladder moves on. A stuck client
+/// must not hold up first frame when the next one down would have answered.
+const PER_CLIENT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(6000);
+
+/// Client ladder for playback, best first.
+///
+/// VISIONOS leads because googlevideo serves its formats without a PO token and
+/// without an `n` parameter — it needs neither an attestation Flow cannot mint nor
+/// an nsig solver Flow does not have. The rest are unattested: they still answer,
+/// but googlevideo now stops serving them partway in, so they rank below it and
+/// exist to keep degraded playback working rather than none.
+///
+/// Deliberately excludes the web-family clients (WEB, TVHTML5_*): their formats
+/// arrive ciphered and `n`-throttled, and with no JS solver every URL they return
+/// would be rejected by `validate_stream_url` after the round trip was already
+/// paid. The in-page WebView recovery is how a WEB response is obtained instead.
+const PLAYER_CLIENT_LADDER: &[&clients::YouTubeClient] = &[
+    &clients::VISIONOS,
+    &clients::ANDROID_VR,
+    &clients::ANDROID_VR_NO_AUTH,
+    &clients::ANDROID,
+    &clients::IOS,
+];
+
+/// Clients asked for a live broadcast's HLS/DASH manifest when the winning
+/// client returned none. A live stream plays from its manifest, so this only
+/// needs a client that exposes one — not one with a usable direct ladder.
+const LIVE_MANIFEST_CLIENTS: &[&clients::YouTubeClient] = &[
+    &clients::IOS,
+    &clients::VISIONOS,
+    &clients::TVHTML5_SIMPLY_EMBEDDED_PLAYER,
+];
+
+/// The winning client of a ladder walk, plus what it was attested with.
+struct PlayerAttempt {
+    response: Value,
+    client: &'static clients::YouTubeClient,
+    po_token: Option<String>,
+}
 
 fn parse_timestamp(s: &str) -> Option<u64> {
     let cleaned: String = s
@@ -252,13 +280,6 @@ fn check_needs_reload(val: &Value) -> bool {
         }
     }
     false
-}
-
-fn is_terminal_playability_status(status: &str) -> bool {
-    matches!(
-        status.to_ascii_uppercase().as_str(),
-        "LIVE_STREAM_OFFLINE" | "UNPLAYABLE" | "ERROR"
-    )
 }
 
 /// Collects the human-readable reason from a playability status, combining the
@@ -714,8 +735,42 @@ fn collect_caption_tracks(response: &Value) -> Vec<CaptionTrack> {
 // Build the audio track list from a player response's `adaptiveFormats`. The PO
 // token is never appended to these GVS media URLs (it belongs only on the player
 // request body and the SABR `StreamerContext`); a stale/wrong `&pot=` 403s.
-fn collect_audio_tracks(streaming_data: &Value, user_agent: &str) -> Vec<AudioTrack> {
-    let mut tracks_by_key: HashMap<String, AudioTrack> = HashMap::new();
+/// One audio format plus the signals used to choose between duplicates of it.
+///
+/// Needed because a client can return the same itag more than once: VISIONOS
+/// ships a plain copy and an `xtags`-tagged variant (descriptive/dubbed content)
+/// of every audio itag, and both carry identical identity fields, so they collide
+/// on the same dedup key.
+struct AudioCandidate {
+    track: AudioTrack,
+    /// `audioIsDefault` as the response stated it, if it stated anything at all.
+    declared_default: Option<bool>,
+    is_auto_dubbed: bool,
+    has_xtags: bool,
+}
+
+impl AudioCandidate {
+    /// Preference order between two formats that share an identity key, best last.
+    ///
+    /// The plain twin outranks the `xtags` one regardless of bitrate: googlevideo
+    /// refuses sustained playback on the tagged variants, so a higher bitrate there
+    /// buys a stream that dies partway in.
+    fn rank(&self) -> (bool, bool, bool, u64) {
+        (
+            !self.has_xtags,
+            self.declared_default.unwrap_or(false),
+            !self.is_auto_dubbed,
+            self.track.bitrate.unwrap_or(0),
+        )
+    }
+}
+
+/// Resolve the audio tracks a player response offers, one per audio identity.
+///
+/// Public so `tests/audio_tracks.rs` can exercise the duplicate-resolution rules
+/// against real response shapes; nothing outside extraction calls it.
+pub fn collect_audio_tracks(streaming_data: &Value, user_agent: &str) -> Vec<AudioTrack> {
+    let mut candidates_by_key: HashMap<String, AudioCandidate> = HashMap::new();
 
     if let Some(adaptive_formats) = streaming_data["adaptiveFormats"].as_array() {
         for format in adaptive_formats {
@@ -755,9 +810,14 @@ fn collect_audio_tracks(streaming_data: &Value, user_agent: &str) -> Vec<AudioTr
             let (init_range_start, init_range_end) = parse_range_value(&format["initRange"]);
             let (index_range_start, index_range_end) = parse_range_value(&format["indexRange"]);
             let is_auto_dubbed = audio_track["isAutoDubbed"].as_bool().unwrap_or(false);
-            let is_default = audio_track["audioIsDefault"]
-                .as_bool()
-                .unwrap_or_else(|| !is_auto_dubbed && tracks_by_key.is_empty());
+            // Only the response's own claim — never position in the list. Deriving
+            // it positionally meant the flag could be silently dropped when a later
+            // duplicate replaced the entry holding it, leaving no default at all.
+            let declared_default = audio_track["audioIsDefault"].as_bool();
+            let has_xtags = format["xtags"]
+                .as_str()
+                .is_some_and(|value| !value.is_empty());
+            let is_default = declared_default.unwrap_or(false);
             let mime_type = format["mimeType"].as_str().map(ToOwned::to_owned);
             let track_key = audio_track_identity_key(
                 audio_track,
@@ -765,37 +825,64 @@ fn collect_audio_tracks(streaming_data: &Value, user_agent: &str) -> Vec<AudioTr
                 language_code.as_deref(),
                 mime_type.as_deref(),
             );
-            let track = AudioTrack {
-                id: format!("{id}-{itag}"),
-                label,
-                language_code,
-                audio_track_type: Some(
-                    if is_default { "original" } else { "alternate" }.to_string(),
-                ),
-                local_url,
-                mime_type,
-                bitrate,
-                content_length: parse_content_length(format),
-                is_default,
-                available: is_default,
-                init_range_start,
-                init_range_end,
-                index_range_start,
-                index_range_end,
-                approx_duration_ms: parse_approx_duration_ms(format),
-                user_agent: Some(user_agent.to_string()),
+            let candidate = AudioCandidate {
+                track: AudioTrack {
+                    id: format!("{id}-{itag}"),
+                    label,
+                    language_code,
+                    audio_track_type: Some(
+                        if is_default { "original" } else { "alternate" }.to_string(),
+                    ),
+                    local_url,
+                    mime_type,
+                    bitrate,
+                    content_length: parse_content_length(format),
+                    is_default,
+                    available: is_default,
+                    init_range_start,
+                    init_range_end,
+                    index_range_start,
+                    index_range_end,
+                    approx_duration_ms: parse_approx_duration_ms(format),
+                    user_agent: Some(user_agent.to_string()),
+                },
+                declared_default,
+                is_auto_dubbed,
+                has_xtags,
             };
 
-            match tracks_by_key.get(&track_key) {
-                Some(existing) if existing.bitrate.unwrap_or(0) >= track.bitrate.unwrap_or(0) => {}
+            match candidates_by_key.get(&track_key) {
+                Some(existing) if existing.rank() >= candidate.rank() => {}
                 _ => {
-                    tracks_by_key.insert(track_key, track);
+                    candidates_by_key.insert(track_key, candidate);
                 }
             }
         }
     }
 
-    let mut tracks: Vec<_> = tracks_by_key.into_values().collect();
+    let mut candidates: Vec<AudioCandidate> = candidates_by_key.into_values().collect();
+    candidates.sort_by(|a, b| b.rank().cmp(&a.rank()));
+
+    // Many responses never flag a default at all — VISIONOS omits `audioTrack`
+    // entirely on videos with no dubs. Promote the best candidate rather than
+    // returning a list with no default: `build_synthetic_dash_manifest` selects on
+    // that flag, and with nothing marked it emits no manifest, which degrades
+    // playback to a video-only stream with no audio at all.
+    if !candidates
+        .iter()
+        .any(|candidate| candidate.track.is_default)
+    {
+        if let Some(best) = candidates.first_mut() {
+            best.track.is_default = true;
+            best.track.available = true;
+            best.track.audio_track_type = Some("original".to_string());
+        }
+    }
+
+    let mut tracks: Vec<AudioTrack> = candidates
+        .into_iter()
+        .map(|candidate| candidate.track)
+        .collect();
     tracks.sort_by(|a, b| {
         b.is_default
             .cmp(&a.is_default)
@@ -976,7 +1063,7 @@ fn build_sabr_metadata(
     video_id: &str,
     visitor_data: Option<String>,
     po_token: Option<String>,
-    client_name: &str,
+    client: &clients::YouTubeClient,
     duration_seconds: Option<u64>,
 ) -> (Option<SabrStreamInfo>, Option<SabrSessionDescriptor>) {
     let server_url = extract_server_abr_url(streaming_data);
@@ -990,7 +1077,7 @@ fn build_sabr_metadata(
     // Observability: one structured line capturing SABR-capability inputs.
     info!(
         video_id = %video_id,
-        client = %client_name,
+        client = %client.name,
         sabr_url_present = server_url.is_some(),
         ustreamer_config_present = !ustreamer_config.is_empty(),
         po_token_present = po_token.is_some(),
@@ -1063,7 +1150,7 @@ fn build_sabr_metadata(
             visitor_data,
             po_token,
             ustreamer_config,
-            client_profile: ClientProfile::from_client_name(client_name),
+            client_profile: ClientProfile::from_client(client),
             duration_ms,
             formats,
         })
@@ -1072,6 +1159,141 @@ fn build_sabr_metadata(
     };
 
     (Some(info), descriptor)
+}
+
+impl InnertubeClient {
+    /// Walk `ladder` in order, returning the first client whose player response is
+    /// playable.
+    ///
+    /// A definitive restriction (age-gated, private, paid, geo-blocked) seen on any
+    /// client is recorded in `deferred_restriction` so the caller can surface that
+    /// specific reason instead of a generic failure once the ladder is exhausted.
+    async fn try_player_ladder(
+        &self,
+        video_id: &str,
+        ladder: &[&'static clients::YouTubeClient],
+        visitor_data: Option<&str>,
+        deferred_restriction: &mut Option<AppError>,
+    ) -> Option<PlayerAttempt> {
+        for client in ladder {
+            // Only a client whose attestation platform Flow can actually run gets a
+            // token. Injecting a BotGuard token into an IOS/ANDROID_VR/VISIONOS
+            // request is a claim googlevideo validates and refuses, which makes it
+            // strictly worse than sending nothing.
+            let po_token = if client.accepts_web_po_token() {
+                let binding = visitor_data
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or(video_id);
+                generate_po_token(binding).await
+            } else {
+                None
+            };
+
+            let mut response = match self
+                .request_player(video_id, client, visitor_data, po_token.as_deref(), None)
+                .await
+            {
+                Some(value) => value,
+                None => continue,
+            };
+
+            // A `needs reload` response clears if the request looks like it came
+            // from the short link rather than the watch page.
+            if check_needs_reload(&response) {
+                let referer = format!("https://youtu.be/{video_id}");
+                match self
+                    .request_player(
+                        video_id,
+                        client,
+                        visitor_data,
+                        po_token.as_deref(),
+                        Some(&referer),
+                    )
+                    .await
+                {
+                    Some(retry) => response = retry,
+                    None => continue,
+                }
+            }
+
+            let status = response["playabilityStatus"]["status"]
+                .as_str()
+                .unwrap_or_default();
+            if status.eq_ignore_ascii_case("OK") {
+                debug!(video_id = %video_id, client = client.name, "Player ladder resolved");
+                return Some(PlayerAttempt {
+                    response,
+                    client,
+                    po_token,
+                });
+            }
+
+            let mapped = map_playability_error(&response["playabilityStatus"]);
+            if is_definitive_restriction(&mapped) {
+                deferred_restriction.get_or_insert(mapped);
+            }
+            warn!(
+                video_id = %video_id,
+                client = client.name,
+                status = %status,
+                "Player client returned a non-OK status, trying the next one"
+            );
+        }
+        None
+    }
+
+    /// One `player` request as `client`, carrying whatever that client's profile
+    /// asks for: signature timestamp, embed URL, PO token.
+    async fn request_player(
+        &self,
+        video_id: &str,
+        client: &clients::YouTubeClient,
+        visitor_data: Option<&str>,
+        po_token: Option<&str>,
+        referer: Option<&str>,
+    ) -> Option<Value> {
+        let mut context = client.player_context(visitor_data, po_token, None);
+        if client.is_embedded {
+            context["thirdParty"] = serde_json::json!({
+                "embedUrl": format!("https://www.youtube.com/watch?v={video_id}")
+            });
+        }
+
+        let mut payload = serde_json::json!({
+            "context": context,
+            "videoId": video_id,
+            "contentCheckOk": true,
+            "racyCheckOk": true,
+        });
+        if let Some(timestamp) = client.signature_timestamp() {
+            payload["playbackContext"] = serde_json::json!({
+                "contentPlaybackContext": {
+                    "referer": referer.unwrap_or("https://www.youtube.com"),
+                    "signatureTimestamp": timestamp
+                }
+            });
+        }
+        if let Some(referer) = referer {
+            payload["custom_referer"] = serde_json::json!(referer);
+        }
+
+        match tokio::time::timeout(
+            PER_CLIENT_TIMEOUT,
+            self.post_innertube("player", client, &mut payload),
+        )
+        .await
+        {
+            Ok(Ok(value)) => Some(value),
+            Ok(Err(error)) => {
+                warn!(video_id = %video_id, client = client.name, %error, "Player request failed");
+                None
+            }
+            Err(_) => {
+                warn!(video_id = %video_id, client = client.name, "Player request timed out");
+                None
+            }
+        }
+    }
 }
 
 impl InnertubeClient {
@@ -1084,119 +1306,27 @@ impl InnertubeClient {
         // Initialize visitor session token
         let visitor_data = self.fetch_visitor_data().await;
 
-        let mut vr_payload = serde_json::json!({
-            "context": get_android_vr_context(visitor_data.clone()),
-            "videoId": video_id_trimmed,
-            "contentCheckOk": true,
-            "racyCheckOk": true
-        });
-
-        let mut res = self
-            .post_innertube("player", "ANDROID_VR", "1.61.48", &mut vr_payload)
+        let mut deferred_restriction: Option<AppError> = None;
+        let attempt = self
+            .try_player_ladder(
+                video_id_trimmed,
+                PLAYER_CLIENT_LADDER,
+                visitor_data.as_deref(),
+                &mut deferred_restriction,
+            )
             .await;
 
-        let mut should_fallback_to_ios = false;
-        let mut recovered_with_android = false;
-        let mut android_recovery = None;
-        if let Ok(ref val) = res {
-            if check_needs_reload(val) {
-                should_fallback_to_ios = true;
-            } else if let Some(status) = val["playabilityStatus"]["status"].as_str() {
-                if !status.eq_ignore_ascii_case("OK") {
-                    if is_terminal_playability_status(status) {
-                        warn!(status = %status, video_id = %video_id_trimmed, "ANDROID_VR details request returned a terminal playability status; trying ANDROID fallback");
-                        let mut android_payload = serde_json::json!({
-                            "context": get_android_context(visitor_data.clone()),
-                            "videoId": video_id_trimmed,
-                            "contentCheckOk": true,
-                            "racyCheckOk": true
-                        });
-                        if let Ok(Ok(android_res)) = tokio::time::timeout(
-                            std::time::Duration::from_millis(1500),
-                            self.post_innertube(
-                                "player",
-                                "ANDROID",
-                                "21.03.38",
-                                &mut android_payload,
-                            ),
-                        )
-                        .await
-                        {
-                            if android_res["playabilityStatus"]["status"]
-                                .as_str()
-                                .map(|status| status.eq_ignore_ascii_case("OK"))
-                                .unwrap_or(false)
-                            {
-                                android_recovery = Some(android_res);
-                                should_fallback_to_ios = false;
-                                recovered_with_android = true;
-                            }
-                        }
-                        if !recovered_with_android {
-                            return Err(map_playability_error(&val["playabilityStatus"]));
-                        }
-                    }
-                    if !recovered_with_android {
-                        warn!(status = %status, video_id = %video_id_trimmed, "ANDROID_VR details request returned a non-OK playability status, falling back to IOS");
-                        should_fallback_to_ios = true;
-                    }
-                }
+        let res = match attempt {
+            Some(attempt) => attempt.response,
+            None => {
+                return Err(deferred_restriction.unwrap_or_else(|| {
+                    AppError::Extractor(format!(
+                        "No client could load details for video {video_id_trimmed}"
+                    ))
+                }));
             }
-        } else {
-            warn!(video_id = %video_id_trimmed, "ANDROID_VR details request failed, falling back to IOS");
-            should_fallback_to_ios = true;
-        }
-        if let Some(android_res) = android_recovery {
-            res = Ok(android_res);
-        }
+        };
 
-        if should_fallback_to_ios {
-            let mut ios_payload = serde_json::json!({
-                "context": get_ios_context(visitor_data.clone(), None),
-                "videoId": video_id_trimmed,
-                "contentCheckOk": true,
-                "racyCheckOk": true,
-                "playbackContext": {
-                    "contentPlaybackContext": {
-                        "referer": "https://www.youtube.com",
-                        "signatureTimestamp": 19550
-                    }
-                }
-            });
-
-            let mut ios_res = self
-                .post_innertube("player", "IOS", "19.29.1", &mut ios_payload)
-                .await;
-
-            let mut needs_retry = false;
-            if let Ok(ref val) = ios_res {
-                if check_needs_reload(val) {
-                    needs_retry = true;
-                }
-            }
-
-            if needs_retry {
-                let mut retry_payload = serde_json::json!({
-                    "context": get_ios_context(visitor_data, None),
-                    "videoId": video_id_trimmed,
-                    "contentCheckOk": true,
-                    "racyCheckOk": true,
-                    "playbackContext": {
-                        "contentPlaybackContext": {
-                            "referer": format!("https://youtu.be/{}", video_id_trimmed),
-                            "signatureTimestamp": 19550
-                        }
-                    },
-                    "custom_referer": format!("https://youtu.be/{}", video_id_trimmed)
-                });
-                ios_res = self
-                    .post_innertube("player", "IOS", "19.29.1", &mut retry_payload)
-                    .await;
-            }
-            res = ios_res;
-        }
-
-        let res = res?;
         check_playability_status(&res["playabilityStatus"])?;
 
         let details = &res["videoDetails"];
@@ -1227,7 +1357,7 @@ impl InnertubeClient {
             "videoId": &id
         });
         if let Ok(next_res) = self
-            .post_innertube("next", "WEB", "2.20260120.01.00", &mut next_payload)
+            .post_innertube("next", &clients::WEB, &mut next_payload)
             .await
         {
             let mut primary_info = &serde_json::Value::Null;
@@ -1384,7 +1514,7 @@ impl InnertubeClient {
         });
 
         let next_res = self
-            .post_innertube("next", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("next", &clients::WEB, &mut payload)
             .await?;
         let mut related = Vec::new();
         collect_related_content_items(
@@ -1412,138 +1542,31 @@ impl InnertubeClient {
         let visitor_data = self.fetch_visitor_data().await;
         let mut visitor_data_for_sabr = visitor_data.clone();
 
-        // 2. Prefer ANDROID_VR first for faster playback and keep IOS as a signed fallback.
-        let mut vr_payload = serde_json::json!({
-            "context": get_android_vr_context(visitor_data.clone()),
-            "videoId": video_id_trimmed,
-            "contentCheckOk": true,
-            "racyCheckOk": true
-        });
-
-        let mut res = self
-            .post_innertube("player", "ANDROID_VR", "1.61.48", &mut vr_payload)
+        // 2. Walk the client ladder; the first playable response wins.
+        let mut deferred_restriction: Option<AppError> = None;
+        let attempt = self
+            .try_player_ladder(
+                video_id_trimmed,
+                PLAYER_CLIENT_LADDER,
+                visitor_data.as_deref(),
+                &mut deferred_restriction,
+            )
             .await;
 
-        let mut should_fallback_to_ios = false;
-        let mut current_user_agent = ANDROID_VR_USER_AGENT;
-        let mut sabr_client_name = "ANDROID_VR";
-        let mut po_token_used: Option<String> = None;
-        let mut recovered_with_android = false;
-        let mut android_recovery = None;
-        let mut deferred_restriction: Option<AppError> = None;
-
-        if let Ok(ref val) = res {
-            if check_needs_reload(val) {
-                should_fallback_to_ios = true;
-            } else if let Some(status) = val["playabilityStatus"]["status"].as_str() {
-                if !status.eq_ignore_ascii_case("OK") {
-                    if is_terminal_playability_status(status) {
-                        warn!(status = %status, video_id = %video_id_trimmed, "ANDROID_VR returned a terminal playability status; trying ANDROID Shorts fallback");
-                        let mut android_payload = serde_json::json!({
-                            "context": get_android_context(visitor_data.clone()),
-                            "videoId": video_id_trimmed,
-                            "contentCheckOk": true,
-                            "racyCheckOk": true
-                        });
-                        if let Ok(Ok(android_res)) = tokio::time::timeout(
-                            std::time::Duration::from_millis(1500),
-                            self.post_innertube(
-                                "player",
-                                "ANDROID",
-                                "21.03.38",
-                                &mut android_payload,
-                            ),
-                        )
-                        .await
-                        {
-                            if android_res["playabilityStatus"]["status"]
-                                .as_str()
-                                .map(|status| status.eq_ignore_ascii_case("OK"))
-                                .unwrap_or(false)
-                            {
-                                android_recovery = Some(android_res);
-                                recovered_with_android = true;
-                                should_fallback_to_ios = false;
-                                current_user_agent = ANDROID_USER_AGENT;
-                                sabr_client_name = "ANDROID";
-                            }
-                        }
-                        if !recovered_with_android {
-                            return Err(map_playability_error(&val["playabilityStatus"]));
-                        }
-                    }
-                    if !recovered_with_android {
-                        warn!(status = %status, video_id = %video_id_trimmed, "ANDROID_VR returned a non-OK playability status, falling back to IOS");
-                        let mapped = map_playability_error(&val["playabilityStatus"]);
-                        if is_definitive_restriction(&mapped) {
-                            deferred_restriction.get_or_insert(mapped);
-                        }
-                        should_fallback_to_ios = true;
-                    }
-                }
-            }
-        } else {
-            warn!(video_id = %video_id_trimmed, "ANDROID_VR player request failed, falling back to IOS");
-            should_fallback_to_ios = true;
-        }
-        if let Some(android_res) = android_recovery {
-            res = Ok(android_res);
-        }
-
-        if should_fallback_to_ios {
-            // Bind the PO token to the session visitor data so it is valid both
-            // in the player request and when echoed on the GVS media URLs.
-            let pot_binding = visitor_data_for_sabr
-                .as_deref()
-                .filter(|value| !value.is_empty())
-                .unwrap_or(video_id_trimmed);
-            let po_token = generate_po_token(pot_binding).await;
-            po_token_used = po_token.clone();
-            sabr_client_name = "IOS";
-            let mut ios_payload = serde_json::json!({
-                "context": get_ios_context(visitor_data.clone(), po_token.clone()),
-                "videoId": video_id_trimmed,
-                "contentCheckOk": true,
-                "racyCheckOk": true,
-                "playbackContext": {
-                    "contentPlaybackContext": {
-                        "referer": "https://www.youtube.com",
-                        "signatureTimestamp": 19550
-                    }
-                }
-            });
-            let mut ios_res = self
-                .post_innertube("player", "IOS", "19.29.1", &mut ios_payload)
-                .await;
-
-            let mut needs_retry = false;
-            if let Ok(ref val) = ios_res {
-                if check_needs_reload(val) {
-                    needs_retry = true;
-                }
-            }
-
-            if needs_retry {
-                let mut retry_payload = serde_json::json!({
-                    "context": get_ios_context(visitor_data, po_token),
-                    "videoId": video_id_trimmed,
-                    "contentCheckOk": true,
-                    "racyCheckOk": true,
-                    "playbackContext": {
-                        "contentPlaybackContext": {
-                            "referer": format!("https://youtu.be/{}", video_id_trimmed),
-                            "signatureTimestamp": 19550
-                        }
-                    },
-                    "custom_referer": format!("https://youtu.be/{}", video_id_trimmed)
-                });
-                ios_res = self
-                    .post_innertube("player", "IOS", "19.29.1", &mut retry_payload)
-                    .await;
-            }
-            res = ios_res;
-            current_user_agent = IOS_USER_AGENT;
-        }
+        let mut winning_client = attempt
+            .as_ref()
+            .map_or(&clients::VISIONOS, |attempt| attempt.client);
+        let mut po_token_used = attempt
+            .as_ref()
+            .and_then(|attempt| attempt.po_token.clone());
+        let mut res = match attempt {
+            Some(attempt) => Ok(attempt.response),
+            None => Err(deferred_restriction.take().unwrap_or_else(|| {
+                AppError::Extractor(format!(
+                    "No client could resolve a stream for video {video_id_trimmed}"
+                ))
+            })),
+        };
 
         let res_is_ok = matches!(&res, Ok(value)
             if value["playabilityStatus"]["status"]
@@ -1575,8 +1598,7 @@ impl InnertubeClient {
                         .filter(|value| !value.is_empty())
                         .unwrap_or(video_id_trimmed);
                     po_token_used = generate_po_token(pot_binding).await;
-                    sabr_client_name = "WEB";
-                    current_user_agent = WEB_USER_AGENT;
+                    winning_client = &clients::WEB;
                     res = Ok(web_res);
                 }
             }
@@ -1609,36 +1631,26 @@ impl InnertubeClient {
             .as_str()
             .map(ToOwned::to_owned);
 
-        // Live broadcasts are served through the HLS/DASH manifest, not a progressive variant.
-        // The IOS client reliably exposes a live HLS manifest, so fetch it when the primary
-        // client returned none.
+        // Live broadcasts play from the HLS/DASH manifest, not a progressive variant.
+        // When the winning client exposed none, ask the clients that reliably do.
+        // A restriction seen here is discarded: the video already resolved, so a
+        // missing manifest is not the reason to fail it.
         if is_live && hls_manifest_url.is_none() {
-            let pot_binding = visitor_data_for_sabr
-                .as_deref()
-                .filter(|value| !value.is_empty())
-                .unwrap_or(video_id_trimmed);
-            let po_token = generate_po_token(pot_binding).await;
-            let mut live_payload = serde_json::json!({
-                "context": get_ios_context(visitor_data_for_sabr.clone(), po_token),
-                "videoId": video_id_trimmed,
-                "contentCheckOk": true,
-                "racyCheckOk": true,
-                "playbackContext": {
-                    "contentPlaybackContext": {
-                        "referer": "https://www.youtube.com",
-                        "signatureTimestamp": 19550
-                    }
-                }
-            });
-            if let Ok(live_res) = self
-                .post_innertube("player", "IOS", "19.29.1", &mut live_payload)
+            let mut discarded: Option<AppError> = None;
+            if let Some(live) = self
+                .try_player_ladder(
+                    video_id_trimmed,
+                    LIVE_MANIFEST_CLIENTS,
+                    visitor_data_for_sabr.as_deref(),
+                    &mut discarded,
+                )
                 .await
             {
-                if let Some(hls) = live_res["streamingData"]["hlsManifestUrl"].as_str() {
+                if let Some(hls) = live.response["streamingData"]["hlsManifestUrl"].as_str() {
                     hls_manifest_url = Some(hls.to_string());
                 }
                 if dash_manifest_url.is_none() {
-                    if let Some(dash) = live_res["streamingData"]["dashManifestUrl"].as_str() {
+                    if let Some(dash) = live.response["streamingData"]["dashManifestUrl"].as_str() {
                         dash_manifest_url = Some(dash.to_string());
                     }
                 }
@@ -1700,12 +1712,12 @@ impl InnertubeClient {
             .unwrap_or(21600); // Default 6 hours
 
         // Return expiration time and user-agent string joined by | delimiter
-        let composite_expires_at = format!("{}|{}", expires_in_seconds, current_user_agent);
+        let composite_expires_at = format!("{}|{}", expires_in_seconds, winning_client.user_agent);
 
         // Offer only the original audio track. Dubbed/translated languages are
         // delivered as progressive direct URLs that googlevideo 403s for sustained
         // playback in this environment, so they are not surfaced.
-        let download_audio_tracks = collect_audio_tracks(streaming_data, current_user_agent);
+        let download_audio_tracks = collect_audio_tracks(streaming_data, winning_client.user_agent);
         let mut audio_tracks = download_audio_tracks.clone();
         if let Some(idx) = audio_tracks.iter().position(|track| track.is_default) {
             audio_tracks = vec![audio_tracks.swap_remove(idx)];
@@ -1722,7 +1734,7 @@ impl InnertubeClient {
             video_id_trimmed,
             visitor_data_for_sabr,
             po_token_used,
-            sabr_client_name,
+            winning_client,
             duration_seconds,
         );
 
@@ -1748,7 +1760,6 @@ impl InnertubeClient {
 #[cfg(test)]
 mod sabr_live_smoke {
     use super::*;
-    use crate::api::innertube::core::context::get_ipados_context;
     use crate::streaming::sabr::engine::{SabrEngine, SabrEngineConfig};
     use crate::streaming::sabr::selector::{CodecSupport, select_formats};
     use crate::streaming::sabr::session::RequestMode;
@@ -1756,15 +1767,7 @@ mod sabr_live_smoke {
     use std::sync::Arc;
 
     fn ipados_profile() -> ClientProfile {
-        ClientProfile {
-            client_name_id: 5,
-            client_version: "21.03.3".into(),
-            user_agent: IPADOS_USER_AGENT.into(),
-            device_make: "Apple".into(),
-            device_model: "iPad7,6".into(),
-            os_name: "iPadOS".into(),
-            os_version: "17.7.10.21H450".into(),
-        }
+        ClientProfile::from_client(&clients::IPADOS)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1795,14 +1798,18 @@ mod sabr_live_smoke {
         );
 
         let mut payload = serde_json::json!({
-            "context": get_ipados_context(visitor_data.clone(), po_token.clone()),
+            "context": clients::IPADOS.player_context(
+                visitor_data.as_deref(),
+                po_token.as_deref(),
+                None,
+            ),
             "videoId": video_id,
             "contentCheckOk": true,
             "racyCheckOk": true,
             "playbackContext": { "contentPlaybackContext": { "signatureTimestamp": 19550 } }
         });
         let res = client
-            .post_innertube("player", "IOS", "21.03.3", &mut payload)
+            .post_innertube("player", &clients::IPADOS, &mut payload)
             .await
             .expect("ipados player request");
         let streaming_data = &res["streamingData"];
@@ -1950,7 +1957,6 @@ mod sabr_live_smoke {
 #[cfg(test)]
 mod sabr_client_probe {
     use super::*;
-    use crate::api::innertube::core::context::get_ipados_context;
     use crate::streaming::sabr::engine::{SabrEngine, SabrEngineConfig};
     use crate::streaming::sabr::selector::{CodecSupport, derive_audio_tracks, select_formats};
     use crate::streaming::sabr::session::RequestMode;
@@ -1959,47 +1965,36 @@ mod sabr_client_probe {
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
-    struct Candidate {
-        label: &'static str,
-        client_name: &'static str,
-        client_version: &'static str,
-        client_name_id: i32,
-        user_agent: &'static str,
-    }
-
-    fn context_for(c: &Candidate, visitor: Option<String>, pot: Option<String>) -> Value {
-        if c.client_name == "IOS" {
-            return get_ipados_context(visitor, pot);
-        }
-        let mut client = serde_json::json!({
-            "clientName": c.client_name,
-            "clientVersion": c.client_version,
-            "hl": "en",
-            "gl": "US",
-            "utcOffsetMinutes": 0,
-        });
-        if let Some(vd) = visitor {
-            client["visitorData"] = Value::String(vd);
-        }
-        let mut ctx = serde_json::json!({
-            "client": client,
-            "playbackContext": { "contentPlaybackContext": { "signatureTimestamp": 19550 } },
-        });
-        if let Some(token) = pot {
-            ctx["serviceIntegrityDimensions"] = serde_json::json!({ "poToken": token });
+    /// Builds the context straight from the registry, so the probe measures the
+    /// same identity the app actually sends rather than a copy of it.
+    ///
+    /// `pot` is passed through `player_context`, which drops it for any client
+    /// whose attestation platform a BotGuard token is not valid for — so a run
+    /// with `send_pot = true` on an iOS/Android client is the control case
+    /// showing that omitting the token changes nothing for them.
+    fn context_for(
+        client: &clients::YouTubeClient,
+        visitor: Option<String>,
+        pot: Option<String>,
+    ) -> Value {
+        let mut ctx = client.player_context(visitor.as_deref(), pot.as_deref(), None);
+        if let Some(timestamp) = client.signature_timestamp() {
+            ctx["playbackContext"] = serde_json::json!({
+                "contentPlaybackContext": { "signatureTimestamp": timestamp }
+            });
         }
         ctx
     }
 
-    async fn raw_player(video_id: &str, c: &Candidate, ctx: Value) -> Option<Value> {
+    async fn raw_player(video_id: &str, c: &clients::YouTubeClient, ctx: Value) -> Option<Value> {
         let payload = serde_json::json!({
             "context": ctx, "videoId": video_id, "contentCheckOk": true, "racyCheckOk": true,
         });
         let r = reqwest::Client::new()
             .post("https://www.youtube.com/youtubei/v1/player?prettyPrint=false")
             .header(reqwest::header::USER_AGENT, c.user_agent)
-            .header("X-YouTube-Client-Name", c.client_name_id.to_string())
-            .header("X-YouTube-Client-Version", c.client_version)
+            .header("X-YouTube-Client-Name", c.client_id)
+            .header("X-YouTube-Client-Version", c.version)
             .header("Origin", "https://www.youtube.com")
             .header("Referer", "https://www.youtube.com")
             .header("Cookie", "SOCS=CAE=")
@@ -2051,48 +2046,27 @@ mod sabr_client_probe {
         // (candidate, send_pot) — the GVS/SABR endpoint validates the web pot
         // regardless of client, so the question is which client+pot combination
         // sustains a SABR stream past the attestation grace window.
-        let android = Candidate {
-            label: "ANDROID",
-            client_name: "ANDROID",
-            client_version: "21.03.38",
-            client_name_id: 3,
-            user_agent: "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip",
-        };
-        let ipados = Candidate {
-            label: "iPadOS",
-            client_name: "IOS",
-            client_version: "21.03.3",
-            client_name_id: 5,
-            user_agent: "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)",
-        };
-        let candidates: [(&Candidate, bool); 4] = [
-            (&android, true),
-            (&android, false),
-            (&ipados, true),
-            (&ipados, false),
+        // VISIONOS leads the real ladder, so it is the one whose sustain behaviour
+        // matters most here; the other two are the unattested clients it replaced.
+        let candidates: [(&clients::YouTubeClient, bool); 6] = [
+            (&clients::VISIONOS, false),
+            (&clients::VISIONOS, true),
+            (&clients::ANDROID, true),
+            (&clients::ANDROID, false),
+            (&clients::IPADOS, true),
+            (&clients::IPADOS, false),
         ];
 
         for (c, send_pot) in candidates {
             let use_pot = if send_pot { pot.clone() } else { None };
             println!(
-                "==== {} ({} v{}) pot={} ====",
-                c.label, c.client_name, c.client_version, send_pot
+                "==== {} v{} pot_offered={} pot_sent={} ====",
+                c.name,
+                c.version,
+                send_pot,
+                send_pot && c.accepts_web_po_token()
             );
-            let ctx = if c.client_name == "ANDROID" {
-                let mut client_obj = serde_json::json!({
-                    "clientName": "ANDROID", "clientVersion": c.client_version, "hl": "en", "gl": "US", "utcOffsetMinutes": 0
-                });
-                if let Some(vd) = visitor_data.clone() {
-                    client_obj["visitorData"] = Value::String(vd);
-                }
-                let mut ctx = serde_json::json!({ "client": client_obj });
-                if let Some(t) = &use_pot {
-                    ctx["serviceIntegrityDimensions"] = serde_json::json!({ "poToken": t });
-                }
-                ctx
-            } else {
-                context_for(c, visitor_data.clone(), use_pot.clone())
-            };
+            let ctx = context_for(c, visitor_data.clone(), use_pot.clone());
             let res = match raw_player(&video_id, c, ctx).await {
                 Some(v) => v,
                 None => {
@@ -2154,15 +2128,7 @@ mod sabr_client_probe {
                 visitor_data: visitor_data.clone(),
                 po_token: use_pot.clone(),
                 ustreamer_config,
-                client_profile: ClientProfile {
-                    client_name_id: c.client_name_id,
-                    client_version: c.client_version.into(),
-                    user_agent: c.user_agent.into(),
-                    device_make: String::new(),
-                    device_model: String::new(),
-                    os_name: String::new(),
-                    os_version: String::new(),
-                },
+                client_profile: ClientProfile::from_client(c),
                 duration_ms,
                 formats,
             };

--- a/src-tauri/src/api/innertube/extractors/player.rs
+++ b/src-tauri/src/api/innertube/extractors/player.rs
@@ -893,6 +893,79 @@ pub fn collect_audio_tracks(streaming_data: &Value, user_agent: &str) -> Vec<Aud
     tracks
 }
 
+pub fn select_playable_audio_tracks(tracks: &[AudioTrack]) -> Vec<AudioTrack> {
+    let language_key = |track: &AudioTrack| -> String {
+        track
+            .language_code
+            .clone()
+            .unwrap_or_else(|| track.label.clone())
+    };
+    let container = |track: &AudioTrack| -> String {
+        track
+            .mime_type
+            .as_deref()
+            .and_then(|mime| mime.split(';').next())
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    // What the original track resolves to when it is the only one considered.
+    let preferred_container = tracks
+        .iter()
+        .filter(|track| track.is_default)
+        .max_by_key(|track| track.bitrate.unwrap_or(0))
+        .map(container);
+
+    let mut by_language: Vec<(String, AudioTrack)> = Vec::new();
+    for track in tracks {
+        let key = language_key(track);
+        let in_preferred_container = preferred_container
+            .as_ref()
+            .is_none_or(|preferred| container(track) == *preferred);
+        // (container matches, bitrate) — a language that cannot offer the shared
+        // container still gets its best format rather than vanishing from the menu.
+        let rank = (in_preferred_container, track.bitrate.unwrap_or(0));
+
+        match by_language
+            .iter_mut()
+            .find(|(existing, _)| *existing == key)
+        {
+            Some((_, existing)) => {
+                let existing_rank = (
+                    preferred_container
+                        .as_ref()
+                        .is_none_or(|preferred| container(existing) == *preferred),
+                    existing.bitrate.unwrap_or(0),
+                );
+                if rank > existing_rank {
+                    *existing = track.clone();
+                }
+            }
+            None => by_language.push((key, track.clone())),
+        }
+    }
+
+    let mut selected: Vec<AudioTrack> = by_language
+        .into_iter()
+        .map(|(_, track)| track)
+        .map(|mut track| {
+            // Every surviving track carries a direct URL that googlevideo serves,
+            // so all of them are offerable; `available` only ever marks a track the
+            // player must refuse.
+            track.available = true;
+            track
+        })
+        .collect();
+
+    selected.sort_by(|a, b| {
+        b.is_default
+            .cmp(&a.is_default)
+            .then_with(|| a.label.cmp(&b.label))
+    });
+
+    selected
+}
+
 fn audio_track_language_code(audio_track: &Value, id: &str) -> Option<String> {
     if let Some(language_code) = audio_track["languageCode"]
         .as_str()
@@ -1714,16 +1787,17 @@ impl InnertubeClient {
         // Return expiration time and user-agent string joined by | delimiter
         let composite_expires_at = format!("{}|{}", expires_in_seconds, winning_client.user_agent);
 
-        // Offer only the original audio track. Dubbed/translated languages are
-        // delivered as progressive direct URLs that googlevideo 403s for sustained
-        // playback in this environment, so they are not surfaced.
+        // Offer every dubbed language alongside the original. VISIONOS serves these
+        // as direct URLs googlevideo streams in full — the earlier iPadOS-sourced
+        // dubs were the ones it refused, and those are no longer how they are
+        // fetched.
         let download_audio_tracks = collect_audio_tracks(streaming_data, winning_client.user_agent);
-        let mut audio_tracks = download_audio_tracks.clone();
-        if let Some(idx) = audio_tracks.iter().position(|track| track.is_default) {
-            audio_tracks = vec![audio_tracks.swap_remove(idx)];
-        } else {
-            audio_tracks.truncate(1);
-        }
+        let audio_tracks = select_playable_audio_tracks(&download_audio_tracks);
+        debug!(
+            video_id = %video_id_trimmed,
+            languages = audio_tracks.len(),
+            "Resolved selectable audio tracks"
+        );
 
         // Extract SABR metadata (safe: never fails the request, only annotates).
         // SABR is retained only as the original-audio bot-wall fallback.

--- a/src-tauri/src/api/innertube/extractors/playlist.rs
+++ b/src-tauri/src/api/innertube/extractors/playlist.rs
@@ -1,4 +1,5 @@
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     best_video_thumbnail_url, extract_channel_id_from_video_renderer,
     parse_mixed_number_word_to_long,
@@ -307,7 +308,7 @@ impl InnertubeClient {
         };
 
         let res = self
-            .post_innertube("browse", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("browse", &clients::WEB, &mut payload)
             .await?;
 
         let title = extract_playlist_title(&res);

--- a/src-tauri/src/api/innertube/extractors/search.rs
+++ b/src-tauri/src/api/innertube/extractors/search.rs
@@ -1,4 +1,5 @@
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     detect_video_is_live, extract_channel_id_from_video_renderer, extract_continuation_token,
     normalize_youtube_image_url, parse_duration_seconds,
@@ -319,7 +320,7 @@ impl InnertubeClient {
         };
 
         let res = self
-            .post_innertube("search", "WEB", "2.20260120.01.00", &mut payload)
+            .post_innertube("search", &clients::WEB, &mut payload)
             .await?;
         let (items, next_page_token) = parse_innertube_search(res);
 
@@ -383,7 +384,7 @@ impl InnertubeClient {
         }
 
         let res = self
-            .post_innertube("search", "WEB_REMIX", "67", &mut payload)
+            .post_innertube("search", &clients::WEB_REMIX, &mut payload)
             .await?;
         let items = parse_music_search_json(&res);
 

--- a/src-tauri/src/api/innertube/extractors/shorts.rs
+++ b/src-tauri/src/api/innertube/extractors/shorts.rs
@@ -2,7 +2,7 @@ use base64::Engine;
 use serde_json::{Value, json};
 
 use crate::api::innertube::InnertubeClient;
-use crate::api::innertube::core::context::get_android_context;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::normalize_youtube_image_url;
 use crate::errors::AppResult;
 use crate::models::shorts::{ShortItem, ShortsFeed};
@@ -26,7 +26,7 @@ impl InnertubeClient {
     ///
     /// Home feed: `sequence_params = None`. Seeded from a video:
     /// `params = Some(encode_reel_seed_params(id))`. Next page: `sequence_params = Some(token)`.
-    /// The iOS client is used because it returns the portrait overlay renderers.
+    /// ANDROID is used because it returns the portrait overlay renderers.
     pub async fn get_shorts_sequence(
         &self,
         params: Option<String>,
@@ -40,13 +40,12 @@ impl InnertubeClient {
             resolved = visitor_data.is_some(),
             "[shorts] reel visitor_data step"
         );
-        let mut context = get_android_context(visitor_data);
-        if let Some(region) = region.as_deref() {
-            let cleaned = region.trim().to_ascii_uppercase();
-            if cleaned.len() == 2 && cleaned.chars().all(|c| c.is_ascii_alphabetic()) {
-                context["client"]["gl"] = json!(cleaned);
-            }
-        }
+        let region = region
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_uppercase)
+            .filter(|value| value.len() == 2 && value.chars().all(|c| c.is_ascii_alphabetic()));
+        let context = clients::ANDROID.context(visitor_data.as_deref(), region.as_deref());
 
         let mut payload = json!({ "context": context });
         if let Some(params) = params {
@@ -61,12 +60,7 @@ impl InnertubeClient {
         }
 
         let res = self
-            .post_innertube(
-                "reel/reel_watch_sequence",
-                "ANDROID",
-                "21.03.38",
-                &mut payload,
-            )
+            .post_innertube("reel/reel_watch_sequence", &clients::ANDROID, &mut payload)
             .await?;
 
         let feed = parse_reel_sequence(&res);

--- a/src-tauri/src/api/innertube/extractors/trending.rs
+++ b/src-tauri/src/api/innertube/extractors/trending.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use crate::api::innertube::InnertubeClient;
+use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     best_video_thumbnail_url, build_related_content_from_lockup, detect_video_is_live,
     extract_channel_id_from_video_renderer, extract_text_from_value, normalize_youtube_image_url,
@@ -10,7 +11,6 @@ use crate::errors::{AppError, AppResult};
 use crate::models::video::VideoSummary;
 use serde_json::{Value, json};
 
-const WEB_VERSION: &str = "2.20260120.01.00";
 const TRENDING_VIDEOS_PARAMS: &str = "4gIOGgxtb3N0X3BvcHVsYXI%3D";
 const GAMING_CHANNEL_ID: &str = "UCOpNcN46UbXVtpKMrmU4Abg";
 const GAMING_PARAMS: &str = "Egh0cmVuZGluZw%3D%3D";
@@ -87,7 +87,7 @@ impl InnertubeClient {
         payload["params"] = json!(TRENDING_VIDEOS_PARAMS);
 
         let response = self
-            .post_innertube("browse", "WEB", WEB_VERSION, &mut payload)
+            .post_innertube("browse", &clients::WEB, &mut payload)
             .await?;
         let mut videos = Vec::new();
 
@@ -116,7 +116,7 @@ impl InnertubeClient {
         payload["params"] = json!(params);
 
         let response = self
-            .post_innertube("browse", "WEB", WEB_VERSION, &mut payload)
+            .post_innertube("browse", &clients::WEB, &mut payload)
             .await?;
         let mut videos = Vec::new();
 
@@ -134,16 +134,9 @@ impl InnertubeClient {
     }
 
     async fn fetch_charts(&self, chart_type: &str, region: &str) -> AppResult<Vec<VideoSummary>> {
+        let client = &clients::WEB_MUSIC_ANALYTICS;
         let payload = json!({
-            "context": {
-                "client": {
-                    "clientName": "WEB_MUSIC_ANALYTICS",
-                    "clientVersion": "2.0",
-                    "hl": "en",
-                    "gl": region,
-                    "utcOffsetMinutes": 0
-                }
-            },
+            "context": client.context(None, Some(region)),
             "browseId": "FEmusic_analytics_charts_home",
             "query": format!(
                 "perspective=CHART_DETAILS&chart_params_country_code={region}&chart_params_chart_type={chart_type}"
@@ -153,12 +146,9 @@ impl InnertubeClient {
         let response = self
             .client
             .post(CHARTS_ENDPOINT)
-            .header(
-                reqwest::header::USER_AGENT,
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            )
-            .header("X-YouTube-Client-Name", "31")
-            .header("X-YouTube-Client-Version", "2.0")
+            .header(reqwest::header::USER_AGENT, client.user_agent)
+            .header("X-YouTube-Client-Name", client.client_id)
+            .header("X-YouTube-Client-Version", client.version)
             .header("Origin", "https://charts.youtube.com")
             .header("Referer", "https://charts.youtube.com")
             .header("Cookie", "SOCS=CAE=")
@@ -196,17 +186,7 @@ fn sanitize_region(region: &str) -> String {
 }
 
 fn web_payload(region: &str) -> Value {
-    json!({
-        "context": {
-            "client": {
-                "clientName": "WEB",
-                "clientVersion": WEB_VERSION,
-                "hl": "en",
-                "gl": region,
-                "utcOffsetMinutes": 0
-            }
-        }
-    })
+    json!({ "context": clients::WEB.context(None, Some(region)) })
 }
 
 fn collect_videos_from_value(value: &Value, videos: &mut Vec<VideoSummary>) {

--- a/src-tauri/src/api/innertube/music/client.rs
+++ b/src-tauri/src/api/innertube/music/client.rs
@@ -47,7 +47,7 @@ impl InnertubeClient {
     ) -> AppResult<Value> {
         if let Some(obj) = payload.as_object_mut() {
             obj.entry("context")
-                .or_insert_with(|| client.context(visitor_data, "en", "US"));
+                .or_insert_with(|| client.context(visitor_data, None));
         }
 
         let mut url = format!("{}{}?prettyPrint=false", endpoints::MUSIC_BASE, endpoint);
@@ -136,10 +136,9 @@ impl InnertubeClient {
         po_token: Option<&str>,
         visitor_data: Option<&str>,
     ) -> AppResult<Value> {
-        let mut context = client.context(visitor_data, "en", "US");
-        if let Some(tok) = po_token {
-            context["serviceIntegrityDimensions"] = json!({ "poToken": tok });
-        }
+        // `player_context` drops the token unless this client's attestation platform
+        // is the one Flow can actually mint for.
+        let mut context = client.player_context(visitor_data, po_token, None);
         if client.is_embedded {
             context["thirdParty"] = json!({
                 "embedUrl": format!("https://www.youtube.com/watch?v={video_id}")

--- a/src-tauri/src/api/innertube/music/clients.rs
+++ b/src-tauri/src/api/innertube/music/clients.rs
@@ -1,225 +1,37 @@
-//! InnerTube client definitions and the music stream-resolution fallback order.
+//! The music stream-resolution fallback order.
 //!
-//! Mirrors `FlowApp_mobile`'s `YouTubeClient` + `MusicPlayerUtils` client lists,
-//! adapted for the desktop reality: the desktop has **no JS cipher/n-sig solver**,
-//! so the stream resolver only uses clients that return *direct* (un-ciphered)
-//! audio URLs. Web clients (which return `signatureCipher`) are excluded from the
-//! direct-audio path but kept available for metadata via `WEB_REMIX`.
+//! Client identities themselves live in [`crate::api::innertube::core::clients`]
+//! — this module only decides which of them the audio resolver walks, and in what
+//! order. The desktop has **no JS cipher/n-sig solver**, so every client here must
+//! return *direct* (un-ciphered, un-throttled) audio URLs; web clients are used
+//! for metadata via `WEB_REMIX` but never for stream resolution.
 
-use serde_json::{Value, json};
-
-const USER_AGENT_WEB: &str =
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:140.0) Gecko/20100101 Firefox/140.0";
-
-/// A single InnerTube client profile.
-#[derive(Clone, Copy, Debug)]
-pub struct MusicClient {
-    pub name: &'static str,
-    pub version: &'static str,
-    pub client_id: &'static str,
-    pub user_agent: &'static str,
-    pub os_name: Option<&'static str>,
-    pub os_version: Option<&'static str>,
-    pub device_make: Option<&'static str>,
-    pub device_model: Option<&'static str>,
-    pub android_sdk_version: Option<&'static str>,
-    /// Whether the player request should carry a `signatureTimestamp`.
-    pub use_signature_timestamp: bool,
-    /// Embedded player (sends a `thirdParty.embedUrl`) — bypasses age gating.
-    pub is_embedded: bool,
-    /// iOS-family client (we attach a PO token + signatureTimestamp like the
-    /// existing video path does for `IOS`).
-    pub is_ios_family: bool,
-}
-
-impl MusicClient {
-    /// Build the `context` object for this client.
-    #[must_use]
-    pub fn context(&self, visitor_data: Option<&str>, hl: &str, gl: &str) -> Value {
-        let mut client = json!({
-            "clientName": self.name,
-            "clientVersion": self.version,
-            "hl": hl,
-            "gl": gl,
-            "utcOffsetMinutes": 0,
-        });
-        if let Some(v) = self.os_name {
-            client["osName"] = json!(v);
-        }
-        if let Some(v) = self.os_version {
-            client["osVersion"] = json!(v);
-        }
-        if let Some(v) = self.device_make {
-            client["deviceMake"] = json!(v);
-        }
-        if let Some(v) = self.device_model {
-            client["deviceModel"] = json!(v);
-        }
-        if let Some(v) = self.android_sdk_version {
-            client["androidSdkVersion"] = json!(v);
-        }
-        if let Some(vd) = visitor_data {
-            client["visitorData"] = json!(vd);
-        }
-        json!({ "client": client })
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Client definitions
-// ---------------------------------------------------------------------------
-
-/// Primary YouTube Music client — browse/search/next metadata. Returns ciphered
-/// stream URLs on desktop, so it is NOT used for direct stream resolution.
-pub const WEB_REMIX: MusicClient = MusicClient {
-    name: "WEB_REMIX",
-    version: "1.20260213.01.00",
-    client_id: "67",
-    user_agent: USER_AGENT_WEB,
-    os_name: None,
-    os_version: None,
-    device_make: None,
-    device_model: None,
-    android_sdk_version: None,
-    use_signature_timestamp: true,
-    is_embedded: false,
-    is_ios_family: false,
+pub use crate::api::innertube::core::clients::YouTubeClient as MusicClient;
+use crate::api::innertube::core::clients::{
+    ANDROID, ANDROID_CREATOR, ANDROID_VR, ANDROID_VR_1_43_32, ANDROID_VR_NO_AUTH,
+    TVHTML5_SIMPLY_EMBEDDED_PLAYER, VISIONOS,
 };
 
-pub const ANDROID_VR_1_43_32: MusicClient = MusicClient {
-    name: "ANDROID_VR",
-    version: "1.43.32",
-    client_id: "28",
-    user_agent: "com.google.android.apps.youtube.vr.oculus/1.43.32 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/107.0.5284.2)",
-    os_name: Some("Android"),
-    os_version: Some("12"),
-    device_make: Some("Oculus"),
-    device_model: Some("Quest 3"),
-    android_sdk_version: Some("32"),
-    use_signature_timestamp: false,
-    is_embedded: false,
-    is_ios_family: false,
-};
+pub use crate::api::innertube::core::clients::WEB_REMIX;
 
-pub const ANDROID_VR_1_61_48: MusicClient = MusicClient {
-    name: "ANDROID_VR",
-    version: "1.61.48",
-    client_id: "28",
-    user_agent: "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
-    os_name: Some("Android"),
-    os_version: Some("12"),
-    device_make: Some("Oculus"),
-    device_model: Some("Quest 3"),
-    android_sdk_version: Some("32"),
-    use_signature_timestamp: false,
-    is_embedded: false,
-    is_ios_family: false,
-};
-
-pub const ANDROID_VR_NO_AUTH: MusicClient = MusicClient {
-    name: "ANDROID_VR",
-    version: "1.61.48",
-    client_id: "28",
-    user_agent: "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Oculus Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
-    os_name: Some("Android"),
-    os_version: Some("12"),
-    device_make: Some("Oculus"),
-    device_model: Some("Quest 3"),
-    android_sdk_version: Some("32"),
-    use_signature_timestamp: false,
-    is_embedded: false,
-    is_ios_family: false,
-};
-
-pub const IOS: MusicClient = MusicClient {
-    name: "IOS",
-    version: "21.03.1",
-    client_id: "5",
-    user_agent: "com.google.ios.youtube/21.03.1 (iPhone16,2; U; CPU iOS 18_2 like Mac OS X;)",
-    os_name: Some("iOS"),
-    os_version: Some("18.2.22C152"),
-    device_make: Some("Apple"),
-    device_model: Some("iPhone16,2"),
-    android_sdk_version: None,
-    use_signature_timestamp: true,
-    is_embedded: false,
-    is_ios_family: true,
-};
-
-pub const IPADOS: MusicClient = MusicClient {
-    name: "IOS",
-    version: "21.03.3",
-    client_id: "5",
-    user_agent: "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)",
-    os_name: Some("iPadOS"),
-    os_version: Some("17.7.10.21H450"),
-    device_make: Some("Apple"),
-    device_model: Some("iPad7,6"),
-    android_sdk_version: None,
-    use_signature_timestamp: true,
-    is_embedded: false,
-    is_ios_family: true,
-};
-
-pub const ANDROID_MOBILE: MusicClient = MusicClient {
-    name: "ANDROID",
-    version: "21.03.38",
-    client_id: "3",
-    user_agent: "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip",
-    os_name: Some("Android"),
-    os_version: Some("14"),
-    device_make: Some("Google"),
-    device_model: Some("Pixel 6 Pro"),
-    android_sdk_version: Some("34"),
-    use_signature_timestamp: true,
-    is_embedded: false,
-    is_ios_family: false,
-};
-
-pub const ANDROID_CREATOR: MusicClient = MusicClient {
-    name: "ANDROID_CREATOR",
-    version: "25.03.101",
-    client_id: "14",
-    user_agent: "com.google.android.apps.youtube.creator/25.03.101 (Linux; U; Android 15; en_US; Pixel 9 Pro Fold; Build/AP3A.241005.015.A2; Cronet/132.0.6779.0)",
-    os_name: Some("Android"),
-    os_version: Some("15"),
-    device_make: Some("Google"),
-    device_model: Some("Pixel 9 Pro Fold"),
-    android_sdk_version: Some("35"),
-    use_signature_timestamp: true,
-    is_embedded: false,
-    is_ios_family: false,
-};
-
-pub const TVHTML5_SIMPLY_EMBEDDED_PLAYER: MusicClient = MusicClient {
-    name: "TVHTML5_SIMPLY_EMBEDDED_PLAYER",
-    version: "2.0",
-    client_id: "85",
-    user_agent: "Mozilla/5.0 (PlayStation; PlayStation 4/12.02) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Safari/605.1.15",
-    os_name: None,
-    os_version: None,
-    device_make: None,
-    device_model: None,
-    android_sdk_version: None,
-    use_signature_timestamp: true,
-    is_embedded: true,
-    is_ios_family: false,
-};
-
-/// Ordered fallback chain for **direct** audio stream resolution on desktop.
+/// Ordered fallback chain for **direct** audio stream resolution.
 ///
-/// Mirrors the spirit of `FlowApp_mobile`'s `FAST_DIRECT_STREAM_CLIENTS`: VR
-/// (non-ABR `1.43.32` first — smoothest for music), then iOS/iPad, then the
-/// Android phone/creator clients, then the embedded TV player as an
-/// age-restriction bypass. Every one of these returns plain `url` fields, so no
-/// cipher/n-sig solver is required.
+/// VISIONOS leads: it is the only direct client googlevideo still serves past the
+/// first minute without a PO token, which is what used to cut tracks off mid-play
+/// and stall playlists. The VR builds follow (1.43.32 first — non-ABR, smoothest
+/// for music), then the Android phone/creator clients, then the embedded TV player
+/// as an age-restriction bypass.
+///
+/// IOS and IPADOS were removed: they now return SABR-only responses carrying no
+/// direct URLs at all, so every attempt cost a round trip and produced nothing.
+/// They were also the two clients being handed a BotGuard token that iOSGuard
+/// clients cannot use — see `AttestationPlatform`.
 pub const DIRECT_AUDIO_CLIENTS: &[MusicClient] = &[
+    VISIONOS,
     ANDROID_VR_1_43_32,
-    ANDROID_VR_1_61_48,
+    ANDROID_VR,
     ANDROID_VR_NO_AUTH,
-    IPADOS,
-    IOS,
-    ANDROID_MOBILE,
+    ANDROID,
     ANDROID_CREATOR,
     TVHTML5_SIMPLY_EMBEDDED_PLAYER,
 ];

--- a/src-tauri/src/api/innertube/music/playback.rs
+++ b/src-tauri/src/api/innertube/music/playback.rs
@@ -20,10 +20,6 @@ use crate::api::innertube::core::botguard::generate_po_token;
 use crate::errors::{AppError, AppResult};
 use crate::models::music_stream::{MusicAudioQuality, MusicStreamInfo};
 
-/// Desktop iOS/Android signed-client signature timestamp (matches the value the
-/// working video path uses for `IOS`).
-const SIGNATURE_TIMESTAMP: i64 = 19550;
-
 impl InnertubeClient {
     /// Resolve a playable, audio-only stream for a music `video_id` by trying
     /// each direct-audio client in turn. Returns the raw upstream URL + the
@@ -43,18 +39,19 @@ impl InnertubeClient {
         let mut last_error: Option<AppError> = None;
 
         for client in clients::DIRECT_AUDIO_CLIENTS {
-            // iOS-family clients get a PO token (sidecar) + signatureTimestamp,
-            // mirroring the video path's IOS fallback. Android/VR need neither.
-            let (sts, pot) = if client.is_ios_family {
+            // Only a client Flow can attest gets a token, and it is bound to the same
+            // visitor data the request carries — a token bound to anything else is
+            // rejected, which is what binding it to the video id used to do here.
+            let pot = if client.use_web_po_tokens {
                 if po_token.is_none() {
-                    po_token = generate_po_token(video_id).await;
+                    let binding = visitor.as_deref().unwrap_or(video_id);
+                    po_token = generate_po_token(binding).await;
                 }
-                (Some(SIGNATURE_TIMESTAMP), po_token.as_deref())
-            } else if client.use_signature_timestamp {
-                (Some(SIGNATURE_TIMESTAMP), None)
+                po_token.as_deref()
             } else {
-                (None, None)
+                None
             };
+            let sts = client.signature_timestamp();
 
             let res = match self
                 .music_player(client, video_id, sts, pot, visitor.as_deref())

--- a/src-tauri/src/commands/downloads/sidecars.rs
+++ b/src-tauri/src/commands/downloads/sidecars.rs
@@ -12,8 +12,6 @@ use crate::commands::youtube::fetch_sponsorblock_segments;
 use crate::db::settings::get_setting;
 use crate::services::music_service::MusicService;
 
-const IMAGE_USER_AGENT: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-
 const THUMBNAILS_ENABLED_KEY: &str = "download_thumbnails_enabled";
 const THUMBNAIL_MODE_KEY: &str = "download_thumbnail_mode";
 
@@ -133,7 +131,7 @@ async fn write_poster(
 
 async fn fetch_poster(url: &str) -> Result<(Vec<u8>, &'static str), String> {
     let client = reqwest::Client::builder()
-        .user_agent(IMAGE_USER_AGENT)
+        .user_agent(crate::api::http::BROWSER_USER_AGENT)
         .connect_timeout(Duration::from_secs(10))
         .timeout(Duration::from_secs(30))
         .build()

--- a/src-tauri/src/commands/music.rs
+++ b/src-tauri/src/commands/music.rs
@@ -22,7 +22,6 @@ use crate::services::music_service::MusicService;
 use crate::streaming::proxy::StreamingManager;
 
 type CmdResult<T> = Result<T, ErrorResponse>;
-const IMAGE_PROXY_UA: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
 // --- Browse ---------------------------------------------------------------
 
@@ -412,7 +411,7 @@ pub async fn proxy_image_url(
         token.clone(),
         upstream_url.clone(),
         image_content_type(&upstream_url),
-        IMAGE_PROXY_UA.to_string(),
+        crate::api::http::BROWSER_USER_AGENT.to_string(),
     );
 
     Ok(format!(

--- a/src-tauri/src/commands/youtube.rs
+++ b/src-tauri/src/commands/youtube.rs
@@ -272,14 +272,18 @@ fn escape_xml_attr(value: &str) -> String {
         .replace('>', "&gt;")
 }
 
-fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
+/// Build a DASH manifest for responses YouTube serves without one.
+///
+/// Public so `tests/dash_manifest.rs` can assert the audio contract the player
+/// depends on; nothing outside this module calls it.
+pub fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
     let has_segment_ranges =
         |init_s: Option<u64>, init_e: Option<u64>, idx_s: Option<u64>, idx_e: Option<u64>| {
             init_s.is_some() && init_e.is_some() && idx_s.is_some() && idx_e.is_some()
         };
     let is_mp4 = |mime: Option<&str>| mime.map(|m| m.contains("mp4")).unwrap_or(false);
 
-    let usable_audio: Vec<_> = stream_info
+    let audio_tracks: Vec<_> = stream_info
         .audio_tracks
         .iter()
         .filter(|track| {
@@ -292,33 +296,6 @@ fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
                 )
         })
         .collect();
-
-    // Only the original (default) audio is offered, but never let a missing
-    // default flag mean *no* audio: emitting no manifest drops playback to the
-    // progressive URL, and the clients that omit the flag are the same ones that
-    // serve no muxed format — so the fallback is a video-only stream, silent.
-    let default_audio: Vec<_> = usable_audio
-        .iter()
-        .copied()
-        .filter(|track| track.is_default)
-        .collect();
-    let audio_tracks = if default_audio.is_empty() {
-        usable_audio
-    } else {
-        default_audio
-    };
-
-    let mp4_audio_tracks: Vec<_> = audio_tracks
-        .iter()
-        .copied()
-        .filter(|track| is_mp4(track.mime_type.as_deref()))
-        .collect();
-
-    let audio_tracks = if mp4_audio_tracks.is_empty() {
-        audio_tracks
-    } else {
-        mp4_audio_tracks
-    };
 
     if audio_tracks.is_empty() {
         return None;
@@ -464,7 +441,7 @@ fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
         ));
         manifest.push_str(&format!(
             "        <BaseURL>{}</BaseURL>\n",
-            audio_track.local_url
+            escape_xml_attr(&audio_track.local_url)
         ));
         manifest.push_str(&format!(
             "        <SegmentBase indexRange=\"{}-{}\">\n",
@@ -499,7 +476,7 @@ fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
             ));
             manifest.push_str(&format!(
                 "        <BaseURL>{}</BaseURL>\n",
-                variant.local_url
+                escape_xml_attr(&variant.local_url)
             ));
             manifest.push_str(&format!(
                 "        <SegmentBase indexRange=\"{}-{}\">\n",

--- a/src-tauri/src/commands/youtube.rs
+++ b/src-tauri/src/commands/youtube.rs
@@ -1,6 +1,7 @@
 use tauri::State;
 use tracing::info;
 
+use crate::api::innertube::core::clients;
 use crate::errors::ErrorResponse;
 use crate::models::channel::{ChannelDetails, ChannelTabResponse};
 use crate::models::comment::CommentsResponse;
@@ -278,13 +279,11 @@ fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
         };
     let is_mp4 = |mime: Option<&str>| mime.map(|m| m.contains("mp4")).unwrap_or(false);
 
-    let audio_tracks: Vec<_> = stream_info
+    let usable_audio: Vec<_> = stream_info
         .audio_tracks
         .iter()
         .filter(|track| {
-            // Only the original (default) audio is offered; carry it in the manifest.
-            track.is_default
-                && !track.local_url.is_empty()
+            !track.local_url.is_empty()
                 && has_segment_ranges(
                     track.init_range_start,
                     track.init_range_end,
@@ -293,6 +292,21 @@ fn build_synthetic_dash_manifest(stream_info: &StreamInfo) -> Option<String> {
                 )
         })
         .collect();
+
+    // Only the original (default) audio is offered, but never let a missing
+    // default flag mean *no* audio: emitting no manifest drops playback to the
+    // progressive URL, and the clients that omit the flag are the same ones that
+    // serve no muxed format — so the fallback is a video-only stream, silent.
+    let default_audio: Vec<_> = usable_audio
+        .iter()
+        .copied()
+        .filter(|track| track.is_default)
+        .collect();
+    let audio_tracks = if default_audio.is_empty() {
+        usable_audio
+    } else {
+        default_audio
+    };
 
     let mp4_audio_tracks: Vec<_> = audio_tracks
         .iter()
@@ -569,10 +583,13 @@ pub async fn get_stream_info(
 
     let parts: Vec<&str> = stream_info.expires_at.split('|').collect();
     let clean_expires_at = parts[0].to_string();
-    let dynamic_user_agent = parts.get(1).map(|&s| s.to_string()).unwrap_or_else(|| {
-        "com.google.ios.youtube/19.29.1 (iPhone14,5; U; CPU iOS 17_5_1 like Mac OS X; en_US)"
-            .to_string()
-    });
+    // Extraction appends the winning client's User-Agent to `expires_at`; the
+    // fallback is the client that leads the ladder, so a missing suffix still
+    // fetches with an identity the registry knows rather than a stale literal.
+    let dynamic_user_agent = parts
+        .get(1)
+        .map(|&s| s.to_string())
+        .unwrap_or_else(|| clients::VISIONOS.user_agent.to_string());
     let proxy_port = streaming_manager.get_port();
 
     if let Some(manifest_url) = stream_info
@@ -656,7 +673,7 @@ pub async fn get_stream_info(
             caption_token.clone(),
             caption.url.clone(),
             "text/vtt; charset=utf-8".to_string(),
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36".to_string(),
+            crate::api::http::BROWSER_USER_AGENT.to_string(),
         );
 
         caption.url = format!("http://127.0.0.1:{}/stream/{}", proxy_port, caption_token);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -13,7 +13,7 @@ mod errors;
 mod flow_neuro;
 #[cfg(target_os = "linux")]
 mod linux_startup;
-mod models;
+pub mod models;
 mod music_brain;
 mod security;
 mod services;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@
 #![warn(clippy::pedantic)]
 #![allow(clippy::missing_errors_doc)]
 
-mod api;
+pub mod api;
 mod bridge;
 #[cfg(target_os = "linux")]
 mod codec_probe;

--- a/src-tauri/src/services/notification_service.rs
+++ b/src-tauri/src/services/notification_service.rs
@@ -46,7 +46,7 @@ fn now_millis() -> i64 {
 
 fn build_client() -> reqwest::Client {
     reqwest::Client::builder()
-        .user_agent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+        .user_agent(crate::api::http::BROWSER_USER_AGENT)
         .timeout(Duration::from_secs(30))
         .build()
         .unwrap_or_default()

--- a/src-tauri/src/streaming/proxy.rs
+++ b/src-tauri/src/streaming/proxy.rs
@@ -7,6 +7,7 @@ use tokio::net::{TcpListener, TcpStream};
 use tracing::{debug, error, info, warn};
 
 use super::sabr::{SabrError, SabrSessionManager, SabrTrack};
+use crate::api::innertube::core::clients;
 
 #[derive(Clone)]
 pub enum StreamSessionKind {
@@ -57,38 +58,33 @@ Access-Control-Allow-Methods: GET, HEAD, OPTIONS\r\n\
 Access-Control-Allow-Headers: Range, Content-Type, Origin, Accept\r\n\
 Access-Control-Expose-Headers: Content-Length, Content-Range, Accept-Ranges\r\n";
 
-// Per-client media User-Agents. googlevideo validates that the UA fetching a
-// stream matches the client (`c=`) that minted the URL; a mismatch (e.g. a web
-// UA on a `c=IOS` URL) is a known cause of 403s.
-const MEDIA_UA_ANDROID_VR: &str = "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)";
-const MEDIA_UA_IOS: &str =
-    "com.google.ios.youtube/19.29.1 (iPhone14,5; U; CPU iOS 17_5_1 like Mac OS X; en_US)";
-const MEDIA_UA_ANDROID: &str = "com.google.android.youtube/19.29.37 (Linux; U; Android 14) gzip";
-const MEDIA_UA_WEB: &str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
-
-// Resolve the upstream User-Agent from a googlevideo URL's `c=` client param,
-// mirroring the mobile player's `YouTubeHttpDataSource.resolveYouTubeUserAgent`.
-// Falls back to the session UA when the URL carries no recognizable `c=` (e.g.
-// manifest/caption proxy URLs).
-fn user_agent_for_media_url(url: &str, fallback: &str) -> String {
-    let client = reqwest::Url::parse(url).ok().and_then(|parsed| {
-        parsed
-            .query_pairs()
-            .find(|(key, _)| key == "c")
-            .map(|(_, value)| value.into_owned())
-    });
-    match client.as_deref() {
-        Some("ANDROID_VR") => MEDIA_UA_ANDROID_VR.to_string(),
-        Some("IOS") => MEDIA_UA_IOS.to_string(),
-        Some("ANDROID") | Some("ANDROID_CREATOR") => MEDIA_UA_ANDROID.to_string(),
-        Some("WEB")
-        | Some("MWEB")
-        | Some("WEB_REMIX")
-        | Some("WEB_CREATOR")
-        | Some("TVHTML5")
-        | Some("TVHTML5_SIMPLY_EMBEDDED_PLAYER") => MEDIA_UA_WEB.to_string(),
-        _ => fallback.to_string(),
+// googlevideo validates that the UA fetching a stream matches the client (`c=`)
+// that minted the URL; a mismatch (e.g. a web UA on a `c=IOS` URL) is a known
+// cause of 403s.
+//
+// The session UA is the one the winning client actually used, recorded at
+// extraction time, so it is authoritative and used whenever it is set. The `c=`
+// lookup is the fallback for URLs registered without one (manifest and caption
+// proxy routes), and reads the same client registry the request was built from —
+// previously these were hand-copied constants that had drifted a version behind.
+fn user_agent_for_media_url(url: &str, session_user_agent: &str) -> String {
+    if !session_user_agent.is_empty() {
+        return session_user_agent.to_string();
     }
+
+    reqwest::Url::parse(url)
+        .ok()
+        .and_then(|parsed| {
+            parsed
+                .query_pairs()
+                .find(|(key, _)| key == "c")
+                .map(|(_, value)| value.into_owned())
+        })
+        .and_then(|name| clients::by_name(&name))
+        .map_or_else(
+            || clients::WEB.user_agent.to_string(),
+            |client| client.user_agent.to_string(),
+        )
 }
 
 impl StreamingManager {

--- a/src-tauri/src/streaming/sabr/mod.rs
+++ b/src-tauri/src/streaming/sabr/mod.rs
@@ -37,6 +37,7 @@ use std::sync::{
 };
 use std::time::{Duration, Instant};
 
+use crate::api::innertube::core::clients;
 use engine::{SabrEngine, SabrEngineConfig};
 
 // Immutable inputs needed to drive a SABR session, assembled by extraction.
@@ -67,73 +68,32 @@ pub struct ClientProfile {
 }
 
 impl ClientProfile {
-    // The iOS profile (client id 5) — the client our extractor most reliably
-    // gets a `serverAbrStreamingUrl` from today.
-    pub fn ios() -> Self {
+    /// Derive the SABR identity from the registry entry of the client whose player
+    /// response opened the session, so the two can never disagree.
+    #[must_use]
+    pub fn from_client(client: &clients::YouTubeClient) -> Self {
         Self {
-            client_name_id: 5,
-            client_version: "19.29.1".into(),
-            user_agent:
-                "com.google.ios.youtube/19.29.1 (iPhone14,5; U; CPU iOS 17_5_1 like Mac OS X; en_US)"
-                    .into(),
-            device_make: "Apple".into(),
-            device_model: "iPhone14,5".into(),
-            os_name: "iOS".into(),
-            os_version: "17.5.1".into(),
+            client_name_id: client.client_name_id(),
+            client_version: client.version.to_string(),
+            user_agent: client.user_agent.to_string(),
+            device_make: client.device_make.unwrap_or_default().to_string(),
+            device_model: client.device_model.unwrap_or_default().to_string(),
+            os_name: client.os_name.unwrap_or_default().to_string(),
+            os_version: client.os_version.unwrap_or_default().to_string(),
         }
     }
 
-    // The iPadOS profile (IOS client id 5, iPad build) — the client that reliably
-    // exposes multi-language (dubbed) audio formats plus a SABR streaming URL.
-    pub fn ipados() -> Self {
-        Self {
-            client_name_id: 5,
-            client_version: "21.03.3".into(),
-            user_agent:
-                "com.google.ios.youtube/21.03.3 (iPad7,6; U; CPU iPadOS 17_7_10 like Mac OS X; en-US)"
-                    .into(),
-            device_make: "Apple".into(),
-            device_model: "iPad7,6".into(),
-            os_name: "iPadOS".into(),
-            os_version: "17.7.10.21H450".into(),
-        }
-    }
-
-    pub fn android_vr() -> Self {
-        Self {
-            client_name_id: 28,
-            client_version: "1.61.48".into(),
-            user_agent:
-                "com.google.android.apps.youtube.vr.oculus/1.61.48 (Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)"
-                    .into(),
-            device_make: "Oculus".into(),
-            device_model: "Quest 3".into(),
-            os_name: "Android".into(),
-            os_version: "12".into(),
-        }
-    }
-
-    // Pick a profile from the InnerTube client name the player response came from.
+    /// Resolve by InnerTube client name, for callers that only have the name a
+    /// media URL carries. Unknown names fall back to WEB, which is what an
+    /// unrecognized `c=` parameter most likely is.
+    #[must_use]
     pub fn from_client_name(client_name: &str) -> Self {
-        match client_name {
-            "IOS" => Self::ios(),
-            "ANDROID_VR" => Self::android_vr(),
-            _ => Self::web(),
-        }
+        Self::from_client(clients::by_name(client_name).unwrap_or(&clients::WEB))
     }
 
-    pub fn web() -> Self {
-        Self {
-            client_name_id: 1,
-            client_version: "2.20240101.00.00".into(),
-            user_agent:
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-                    .into(),
-            device_make: String::new(),
-            device_model: String::new(),
-            os_name: "Windows".into(),
-            os_version: "10.0".into(),
-        }
+    #[cfg(test)]
+    pub fn ios() -> Self {
+        Self::from_client(&clients::IOS)
     }
 }
 

--- a/src-tauri/src/sync/brainmap.rs
+++ b/src-tauri/src/sync/brainmap.rs
@@ -48,7 +48,30 @@ fn bucket_to_string(b: &TimeBucket) -> String {
         .unwrap_or_default()
 }
 fn string_to_bucket(s: &str) -> Option<TimeBucket> {
-    serde_json::from_value(serde_json::Value::String(s.to_string())).ok()
+    if let Ok(bucket) = serde_json::from_value(serde_json::Value::String(s.to_string())) {
+        return Some(bucket);
+    }
+    let normalized: String = s
+        .chars()
+        .filter(|c| *c != '_')
+        .flat_map(char::to_lowercase)
+        .collect();
+    match normalized.as_str() {
+        "weekdaymorning" => Some(TimeBucket::WeekdayMorning),
+        "weekdayafternoon" => Some(TimeBucket::WeekdayAfternoon),
+        "weekdayevening" => Some(TimeBucket::WeekdayEvening),
+        "weekdaynight" => Some(TimeBucket::WeekdayNight),
+        "weekendmorning" => Some(TimeBucket::WeekendMorning),
+        "weekendafternoon" => Some(TimeBucket::WeekendAfternoon),
+        "weekendevening" => Some(TimeBucket::WeekendEvening),
+        "weekendnight" => Some(TimeBucket::WeekendNight),
+        _ => None,
+    }
+}
+
+#[must_use]
+pub fn canonical_bucket_key(key: &str) -> Option<String> {
+    string_to_bucket(key).map(|bucket| bucket_to_string(&bucket))
 }
 
 // ---- ContentVector ⇄ ContentVectorWire -------------------------------------------------------

--- a/src-tauri/src/sync/canonical.rs
+++ b/src-tauri/src/sync/canonical.rs
@@ -178,7 +178,10 @@ impl<'de> Deserialize<'de> for Hlc {
 /// counts, interaction totals, play counts) **idempotent on re-sync** while still summing the
 /// genuinely-disjoint history of distinct devices — the precise fix for the double-counting bug
 /// in a naive weighted-average merge.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// Wire form is the map itself (`{"<device>": 12}`). `Deserialize` is hand-written in
+/// [`crate::sync::compat`] so a peer that wraps it differently is still understood.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 #[serde(transparent)]
 pub struct GCounter(pub BTreeMap<String, u64>);
 
@@ -224,11 +227,12 @@ impl GCounter {
 ///
 /// Used for blocklists / preferences / seen-sets, where "blocked on either device ⇒ blocked"
 /// but an explicit unblock must still propagate.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+///
+/// `Deserialize` is hand-written in [`crate::sync::compat`] so a peer that sends a bare member
+/// array (no stamps) is still understood.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct OrSet {
-    #[serde(default)]
     pub adds: BTreeMap<String, Hlc>,
-    #[serde(default)]
     pub removes: BTreeMap<String, Hlc>,
 }
 
@@ -283,7 +287,9 @@ impl OrSet {
 
 /// A last-write-wins register keyed by `Hlc`. The higher stamp wins; the `device_id` tiebreaker
 /// inside `Hlc` makes the resolution deterministic and loss-free under clock skew.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// `Deserialize` is hand-written in [`crate::sync::compat`] so a peer that sends an unstamped bare
+/// value is still understood.
+#[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct Lww<T> {
     pub value: T,
     pub hlc: Hlc,
@@ -430,16 +436,19 @@ pub struct SettingEntry {
 // ===========================================================================================
 
 /// A topic vector plus optional scalar "dimensions" (duration/pacing/complexity/isLive on some
-/// platforms). Kept flexible so both the desktop and Android `ContentVector` shapes map in.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+/// platforms). Kept flexible so both the desktop and Android `ContentVector` shapes map in — the
+/// hand-written `Deserialize` in [`crate::sync::compat`] is what accepts Android's inline dims.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ContentVectorWire {
     pub topics: BTreeMap<String, f64>,
     pub dims: BTreeMap<String, f64>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+/// `Deserialize` is hand-written in [`crate::sync::compat`], which rewrites `time_vectors` keys
+/// into this platform's bucket spelling.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BrainVectors {
     pub global_vector: ContentVectorWire,
     pub time_vectors: BTreeMap<String, ContentVectorWire>,
@@ -529,8 +538,11 @@ pub struct BrainFlags {
 /// deterministically across all known device snapshots.
 /// Device-local/derived fields (`consecutive_skips`, `last_persona`, `persona_stability`,
 /// `recent_query_tokens`) are intentionally **not** part of the wire model.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+///
+/// `Deserialize` is hand-written in [`crate::sync::compat`]: it accepts this grouped layout and the
+/// flat one Flow for Android sends.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct FlowNeuroBrainSnapshot {
     pub schema: i32,
     pub device_id: String,

--- a/src-tauri/src/sync/codec.rs
+++ b/src-tauri/src/sync/codec.rs
@@ -169,11 +169,27 @@ pub fn encode_chunk(header: &ChunkHeader, ndjson: &[u8]) -> Vec<u8> {
 }
 
 /// Decode a CHUNK plaintext body into `(header, ndjson_slice)`.
+///
+/// A frame with **no** newline is read as a header-only chunk (empty body) rather than rejected:
+/// Flow for Android through v2.2.0 builds an empty collection's chunk as `StringBuilder(header)`
+/// and only appends `'\n'` *before each record*, so a zero-record collection arrives as bare header
+/// JSON. Rejecting it killed every phone→desktop sync where any selected collection was empty
+/// (issues #30/#49). `encode_chunk` still always writes the separator, so what we emit stays
+/// spec-exact (`FLOW-SYNC/1` §7); only what we accept is widened.
 pub fn decode_chunk(plaintext: &[u8]) -> Result<(ChunkHeader, &[u8]), SyncError> {
-    let nl = plaintext
-        .iter()
-        .position(|&b| b == b'\n')
-        .ok_or_else(|| SyncError::Codec("chunk frame missing header newline".into()))?;
-    let header: ChunkHeader = serde_json::from_slice(&plaintext[..nl])?;
-    Ok((header, &plaintext[nl + 1..]))
+    let (header_bytes, body) = match plaintext.iter().position(|&b| b == b'\n') {
+        Some(nl) => (&plaintext[..nl], &plaintext[nl + 1..]),
+        None => (plaintext, &plaintext[plaintext.len()..]),
+    };
+    let header: ChunkHeader = serde_json::from_slice(header_bytes)?;
+    if body.is_empty() {
+        tracing::debug!(
+            target: "flow::sync::codec",
+            seq = header.seq,
+            last = header.last,
+            separator_present = plaintext.len() != header_bytes.len(),
+            "decoded an empty chunk body"
+        );
+    }
+    Ok((header, body))
 }

--- a/src-tauri/src/sync/compat.rs
+++ b/src-tauri/src/sync/compat.rs
@@ -1,0 +1,315 @@
+//! Tolerant `Deserialize` impls for the canonical wire model.
+//!
+//! [`crate::sync::canonical`] defines what this build **emits** — the shapes fixed by `FLOW-SYNC/1`
+//! (`notes/sync/sync_wire_format_addendum.md` §6.5). What we **accept** has to be wider, because
+//! Flow for Android through v2.2.0 ships the `FlowNeuro` brain in a flatter envelope and those builds
+//! are already on users' phones. Every impl here still accepts the canonical shape unchanged and
+//! additionally understands the Android one. Serialization is untouched, so nothing in this module
+//! can change the bytes we put on the wire or the payload hashes computed over them.
+//!
+//! What Android (`sync/canonical/Canonical.kt`, `sync/mapping/BrainMapper.kt`) does differently:
+//!
+//! * `GCounter` is wrapped in a `perDevice` object instead of *being* the device→count map. That
+//!   single mismatch aborted the entire apply transaction with
+//!   `invalid type: map, expected u64` — so no collection synced at all whenever the brain was
+//!   selected (issue #46).
+//! * Counters, per-video maps, sets, LWW-maps and flags sit at the top level instead of grouped
+//!   under `counters` / `perVideo` / `sets` / `lwwMaps` / `flags`. Serde ignores unknown fields, so
+//!   these were being dropped *silently* — the brain "synced" while importing nothing.
+//! * OR-Sets arrive as plain arrays and LWW registers as bare values with no stamp. Both are
+//!   stamped with the snapshot's own HLC on the way in, otherwise they would carry the
+//!   lowest-possible clock and lose every subsequent merge.
+//! * `ContentVector` dimensions are inline on the vector rather than inside `dims`.
+
+use std::collections::BTreeMap;
+
+use serde::de::{DeserializeOwned, Error as DeError};
+use serde::{Deserialize, Deserializer};
+use serde_json::{Map, Value};
+
+use crate::sync::brainmap;
+use crate::sync::canonical::{
+    BrainCounters, BrainFlags, BrainLwwMaps, BrainPerVideo, BrainSets, BrainVectors,
+    ContentVectorWire, FlowNeuroBrainSnapshot, GCounter, Hlc, Lww, OrSet,
+};
+
+// ---- shared helpers ---------------------------------------------------------------------------
+
+/// Deserialize `obj[key]`, falling back to `T::default()` when it is absent or null.
+fn field<T, E>(obj: &Map<String, Value>, ctx: &str, key: &str) -> Result<T, E>
+where
+    T: DeserializeOwned + Default,
+    E: DeError,
+{
+    match obj.get(key) {
+        None | Some(Value::Null) => Ok(T::default()),
+        Some(v) => {
+            serde_json::from_value(v.clone()).map_err(|e| E::custom(format!("{ctx}.{key}: {e}")))
+        }
+    }
+}
+
+/// Deserialize the `group` object if the peer nested it, otherwise rebuild it from the top-level
+/// keys a flat-envelope peer used. `members` are the field names, which are identical in both
+/// layouts — only their nesting differs.
+fn group<T, E>(
+    obj: &Map<String, Value>,
+    ctx: &str,
+    group_key: &str,
+    members: &[&str],
+) -> Result<T, E>
+where
+    T: DeserializeOwned + Default,
+    E: DeError,
+{
+    if let Some(nested) = obj.get(group_key).filter(|v| !v.is_null()) {
+        return serde_json::from_value(nested.clone())
+            .map_err(|e| E::custom(format!("{ctx}.{group_key}: {e}")));
+    }
+    let flat: Map<String, Value> = members
+        .iter()
+        .filter_map(|key| {
+            obj.get(*key)
+                .filter(|v| !v.is_null())
+                .map(|v| ((*key).to_string(), v.clone()))
+        })
+        .collect();
+    if flat.is_empty() {
+        return Ok(T::default());
+    }
+    serde_json::from_value(Value::Object(flat))
+        .map_err(|e| E::custom(format!("{ctx}.{group_key} (flat layout): {e}")))
+}
+
+// ---- CRDT primitives --------------------------------------------------------------------------
+
+impl<'de> Deserialize<'de> for GCounter {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(d)?;
+        let obj = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("gCounter must be a JSON object"))?;
+        // Canonical: {"<device>": 12}. Android: {"perDevice": {"<device>": 12}}.
+        let entries = match obj.get("perDevice") {
+            Some(Value::Object(inner)) if obj.len() == 1 => inner,
+            _ => obj,
+        };
+        let mut counts = BTreeMap::new();
+        for (device, count) in entries {
+            // A sub-count is grow-only, so a negative one is nonsense; clamp rather than fail the
+            // whole apply over one bad entry.
+            let n = count
+                .as_u64()
+                .or_else(|| count.as_i64().map(|i| i.max(0).unsigned_abs()))
+                .ok_or_else(|| {
+                    D::Error::custom(format!("gCounter[{device}] must be an integer"))
+                })?;
+            counts.insert(device.clone(), n);
+        }
+        Ok(GCounter(counts))
+    }
+}
+
+impl<'de> Deserialize<'de> for OrSet {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(d)?;
+        match value {
+            // A bare member list (Android, and the §6.5 sketch). Stamps are filled in from the
+            // snapshot's HLC by `stamp_missing_hlcs`.
+            Value::Array(items) => {
+                let mut adds = BTreeMap::new();
+                for item in items {
+                    let member = item
+                        .as_str()
+                        .ok_or_else(|| D::Error::custom("orSet member must be a string"))?;
+                    adds.insert(member.to_string(), Hlc::default());
+                }
+                Ok(OrSet {
+                    adds,
+                    removes: BTreeMap::new(),
+                })
+            }
+            Value::Object(obj) => Ok(OrSet {
+                adds: field(&obj, "orSet", "adds")?,
+                removes: field(&obj, "orSet", "removes")?,
+            }),
+            _ => Err(D::Error::custom("orSet must be an object or an array")),
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Lww<T>
+where
+    T: DeserializeOwned,
+{
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(d)?;
+        // The canonical register is exactly `{"value": …, "hlc": "…"}`. Anything else is a bare
+        // value from a peer that does not stamp its registers — no canonical `T` has both a
+        // `value` and an `hlc` field, so the two cannot be confused.
+        if let Value::Object(obj) = &value
+            && let (2, Some(inner), Some(stamp)) = (obj.len(), obj.get("value"), obj.get("hlc"))
+        {
+            return Ok(Lww {
+                value: serde_json::from_value(inner.clone())
+                    .map_err(|e| D::Error::custom(format!("lww.value: {e}")))?,
+                hlc: serde_json::from_value(stamp.clone())
+                    .map_err(|e| D::Error::custom(format!("lww.hlc: {e}")))?,
+            });
+        }
+        Ok(Lww {
+            value: serde_json::from_value(value)
+                .map_err(|e| D::Error::custom(format!("lww bare value: {e}")))?,
+            hlc: Hlc::default(),
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for ContentVectorWire {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let value = Value::deserialize(d)?;
+        let obj = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("contentVector must be a JSON object"))?;
+        let topics = field(obj, "contentVector", "topics")?;
+        let mut dims: BTreeMap<String, f64> = field(obj, "contentVector", "dims")?;
+        // Android carries duration/pacing/complexity/isLive directly on the vector. Fold in any
+        // scalar sibling so a future dimension needs no change here; an explicit `dims` wins.
+        for (key, v) in obj {
+            if key == "topics" || key == "dims" {
+                continue;
+            }
+            if let Some(n) = v.as_f64() {
+                dims.entry(key.clone()).or_insert(n);
+            }
+        }
+        Ok(ContentVectorWire { topics, dims })
+    }
+}
+
+impl<'de> Deserialize<'de> for BrainVectors {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        const CTX: &str = "brainVectors";
+        let value = Value::deserialize(d)?;
+        let obj = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("brainVectors must be a JSON object"))?;
+
+        let raw: BTreeMap<String, ContentVectorWire> = field(obj, CTX, "timeVectors")?;
+        let mut entries: Vec<(String, bool, ContentVectorWire)> = raw
+            .into_iter()
+            .map(|(key, vector)| match brainmap::canonical_bucket_key(&key) {
+                Some(canonical) => {
+                    let already_canonical = canonical == key;
+                    (canonical, already_canonical, vector)
+                }
+                // Not a bucket name we know — pass it through untouched rather than lose it.
+                None => (key, true, vector),
+            })
+            .collect();
+        // Stable sort puts rewritten spellings first, so a key that was already canonical wins any
+        // collision between the two forms.
+        entries.sort_by_key(|(_, already_canonical, _)| *already_canonical);
+
+        Ok(BrainVectors {
+            global_vector: field(obj, CTX, "globalVector")?,
+            time_vectors: entries.into_iter().map(|(k, _, v)| (k, v)).collect(),
+            shorts_vector: field(obj, CTX, "shortsVector")?,
+            topic_affinities: field(obj, CTX, "topicAffinities")?,
+            channel_scores: field(obj, CTX, "channelScores")?,
+            channel_topic_profiles: field(obj, CTX, "channelTopicProfiles")?,
+        })
+    }
+}
+
+// ---- FlowNeuro brain snapshot -----------------------------------------------------------------
+
+impl<'de> Deserialize<'de> for FlowNeuroBrainSnapshot {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        const CTX: &str = "flowNeuroBrain";
+        let value = Value::deserialize(d)?;
+        let obj = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("flow_neuro_brain record must be a JSON object"))?;
+
+        let mut snapshot = FlowNeuroBrainSnapshot {
+            schema: field(obj, CTX, "schema")?,
+            device_id: field(obj, CTX, "deviceId")?,
+            hlc: field(obj, CTX, "hlc")?,
+            vectors: field::<BrainVectors, _>(obj, CTX, "vectors")?,
+            counters: group::<BrainCounters, _>(
+                obj,
+                CTX,
+                "counters",
+                &["idfTotalDocuments", "totalInteractions"],
+            )?,
+            idf_word_frequency: field(obj, CTX, "idfWordFrequency")?,
+            per_video: group::<BrainPerVideo, _>(
+                obj,
+                CTX,
+                "perVideo",
+                &["watchHistoryMap", "watchSignalProgress"],
+            )?,
+            sets: group::<BrainSets, _>(
+                obj,
+                CTX,
+                "sets",
+                &["blockedTopics", "blockedChannels", "preferredTopics"],
+            )?,
+            lww_maps: group::<BrainLwwMaps, _>(
+                obj,
+                CTX,
+                "lwwMaps",
+                &[
+                    "suppressedVideoIds",
+                    "suppressedChannels",
+                    "rejectionPatterns",
+                    "topicEvidence",
+                    "feedHistory",
+                    "channelStrikes",
+                ],
+            )?,
+            flags: group::<BrainFlags, _>(obj, CTX, "flags", &["hasCompletedOnboarding"])?,
+        };
+        stamp_missing_hlcs(&mut snapshot);
+        Ok(snapshot)
+    }
+}
+
+/// Give every unstamped OR-Set member and LWW register the snapshot's own HLC.
+///
+/// A peer that sends bare values leaves them at `Hlc::default()`, the lowest possible stamp — which
+/// would lose to *any* local write during merge and, worse, lose to an old remove tombstone, so a
+/// channel the user just blocked on the phone would silently unblock here.
+fn stamp_missing_hlcs(snapshot: &mut FlowNeuroBrainSnapshot) {
+    let hlc = snapshot.hlc.clone();
+    if hlc == Hlc::default() {
+        return;
+    }
+    for set in [
+        &mut snapshot.sets.blocked_topics,
+        &mut snapshot.sets.blocked_channels,
+        &mut snapshot.sets.preferred_topics,
+    ] {
+        for stamp in set.adds.values_mut().chain(set.removes.values_mut()) {
+            if *stamp == Hlc::default() {
+                *stamp = hlc.clone();
+            }
+        }
+    }
+    let maps = &mut snapshot.lww_maps;
+    stamp_lww_map(&mut maps.suppressed_video_ids, &hlc);
+    stamp_lww_map(&mut maps.suppressed_channels, &hlc);
+    stamp_lww_map(&mut maps.rejection_patterns, &hlc);
+    stamp_lww_map(&mut maps.topic_evidence, &hlc);
+    stamp_lww_map(&mut maps.feed_history, &hlc);
+    stamp_lww_map(&mut maps.channel_strikes, &hlc);
+}
+
+fn stamp_lww_map<T>(map: &mut BTreeMap<String, Lww<T>>, hlc: &Hlc) {
+    for register in map.values_mut() {
+        if register.hlc == Hlc::default() {
+            register.hlc = hlc.clone();
+        }
+    }
+}

--- a/src-tauri/src/sync/mod.rs
+++ b/src-tauri/src/sync/mod.rs
@@ -2,6 +2,7 @@ pub mod apply;
 pub mod brainmap;
 pub mod canonical;
 pub mod codec;
+pub mod compat;
 pub mod crypto;
 pub mod error;
 pub mod export;

--- a/src-tauri/src/sync/session.rs
+++ b/src-tauri/src/sync/session.rs
@@ -449,7 +449,15 @@ pub async fn start_host(
     let sas = compute_sas(&master, &session_id);
 
     let (listener, port) = transport::bind().await?;
-    let ip = transport::lan_ip().ok_or_else(|| {
+    // Log every candidate, not just the winner: when a pairing fails with "connection error" and no
+    // inbound TCP on this side, the address we advertised is the first thing to check (issue #41).
+    let candidates = transport::lan_ip_candidates();
+    tracing::info!(
+        target: "flow::sync::session",
+        candidates = ?candidates.iter().map(|c| format!("{}={}{}", c.interface, c.ip, if c.virtual_iface { " (virtual)" } else { "" })).collect::<Vec<_>>(),
+        "LAN address candidates, best first"
+    );
+    let ip = candidates.into_iter().next().map(|c| c.ip).ok_or_else(|| {
         SyncError::Transport("no usable LAN IPv4 address found (are you on Wi-Fi/LAN?)".into())
     })?;
     let expires_at = now_s() + HOST_TTL.as_secs();

--- a/src-tauri/src/sync/transport.rs
+++ b/src-tauri/src/sync/transport.rs
@@ -99,21 +99,106 @@ pub async fn connect(
     Ok(WsChannel::new(ws))
 }
 
-/// Best-effort LAN IPv4 for the QR code: skips loopback, link-local (169.254.x), and the
-/// Docker-ish 172.16–172.31 range. Returns the first plausible address, or `None`.
-pub fn lan_ip() -> Option<String> {
-    let ifas = local_ip_address::list_afinet_netifas().ok()?;
-    for (_name, ip) in ifas {
-        if let IpAddr::V4(v4) = ip {
-            if v4.is_loopback() || v4.is_link_local() {
-                continue;
-            }
-            let o = v4.octets();
-            if o[0] == 172 && (16..=31).contains(&o[1]) {
-                continue;
-            }
-            return Some(v4.to_string());
-        }
+/// Interface-name prefixes that mean "virtual, container, or VPN adapter". Matched on the start of
+/// the lowercased name so `wg0-mullvad`, `tun0` and `utun3` are caught without false-positiving on
+/// an arbitrary substring.
+const VIRTUAL_IFACE_PREFIXES: [&str; 8] = ["tun", "tap", "utun", "wg", "ppp", "veth", "br-", "zt"];
+
+/// Distinctive fragments that mean the same thing but can appear anywhere in the (often verbose)
+/// Windows/macOS adapter name, e.g. `vEthernet (WSL)`.
+const VIRTUAL_IFACE_SUBSTRINGS: [&str; 8] = [
+    "docker",
+    "virbr",
+    "vboxnet",
+    "vmnet",
+    "tailscale",
+    "vethernet",
+    "mullvad",
+    "wsl",
+];
+
+/// One candidate address for the QR, with the interface it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanCandidate {
+    pub interface: String,
+    pub ip: String,
+    /// True when the interface looks virtual/VPN — such an address is only ever a last resort.
+    pub virtual_iface: bool,
+}
+
+fn is_virtual_iface(name: &str) -> bool {
+    let n = name.to_ascii_lowercase();
+    VIRTUAL_IFACE_PREFIXES.iter().any(|p| n.starts_with(p))
+        || VIRTUAL_IFACE_SUBSTRINGS.iter().any(|s| n.contains(s))
+}
+
+/// How plausible this address is as "reachable from another device on the same LAN" — lower is
+/// better. `None` rejects the address outright.
+fn address_rank(name: &str, v4: std::net::Ipv4Addr) -> Option<u8> {
+    if v4.is_loopback() || v4.is_link_local() || v4.is_unspecified() || v4.is_multicast() {
+        return None;
     }
-    None
+    let o = v4.octets();
+    let range_rank = match o {
+        [192, 168, _, _] => 0,
+        [10, ..] => 1,
+        // Docker's default bridge (172.17/16) is demoted rather than rejected, so a host whose only
+        // address really is in it still gets a QR.
+        [172, 17, _, _] => 4,
+        [172, b, _, _] if (16..=31).contains(&b) => 2,
+        // CGNAT / Tailscale — routable for that overlay, almost never the LAN the phone is on.
+        [100, b, _, _] if (64..=127).contains(&b) => 5,
+        // A public address: unusual, but some networks hand them out on the same L2 segment.
+        _ => 3,
+    };
+    // A physical interface always beats a virtual one, whatever the range: a VirtualBox host-only
+    // 192.168.56.1 is unreachable, while a physical CGNAT address at least might work.
+    Some(if is_virtual_iface(name) {
+        8 + range_rank
+    } else {
+        range_rank
+    })
+}
+
+/// Rank `interfaces` (as returned by [`local_ip_address::list_afinet_netifas`]) into QR candidates,
+/// best first. Split out from [`lan_ip_candidates`] so the selection policy is testable without
+/// real network interfaces.
+///
+/// Ordering matters because the winner is what the QR tells the phone to dial. The old "first
+/// address that isn't loopback/link-local" rule handed out whatever the OS happened to enumerate
+/// first, which with a VPN up is frequently the tunnel address (Mullvad allocates from `10.64/10`)
+/// — an address that exists only inside the tunnel, so the phone's connection never arrives and the
+/// desktop logs nothing at all (issue #41). Preference order mirrors Android's `LanAddress.resolve`
+/// so both ends of a pair pick comparably.
+pub fn rank_lan_candidates(interfaces: Vec<(String, IpAddr)>) -> Vec<LanCandidate> {
+    let mut ranked: Vec<(u8, LanCandidate)> = interfaces
+        .into_iter()
+        .filter_map(|(name, ip)| {
+            let IpAddr::V4(v4) = ip else { return None };
+            let rank = address_rank(&name, v4)?;
+            Some((
+                rank,
+                LanCandidate {
+                    virtual_iface: is_virtual_iface(&name),
+                    interface: name,
+                    ip: v4.to_string(),
+                },
+            ))
+        })
+        .collect();
+    // Stable, so equally-ranked addresses keep the OS enumeration order.
+    ranked.sort_by_key(|(rank, _)| *rank);
+    ranked.into_iter().map(|(_, c)| c).collect()
+}
+
+/// Every plausible LAN IPv4 on this host, best first — see [`rank_lan_candidates`].
+pub fn lan_ip_candidates() -> Vec<LanCandidate> {
+    local_ip_address::list_afinet_netifas()
+        .map(rank_lan_candidates)
+        .unwrap_or_default()
+}
+
+/// Best-effort LAN IPv4 for the QR code. See [`lan_ip_candidates`] for how the winner is chosen.
+pub fn lan_ip() -> Option<String> {
+    lan_ip_candidates().into_iter().next().map(|c| c.ip)
 }

--- a/src-tauri/tests/audio_tracks.rs
+++ b/src-tauri/tests/audio_tracks.rs
@@ -1,0 +1,218 @@
+//! Guards on audio-track resolution.
+//!
+//! Every case here is a real response shape that broke playback: the selected
+//! audio must always end up with exactly one track flagged default, because the
+//! synthetic DASH builder keys the audio AdaptationSet off that flag. When no
+//! track carries it the manifest comes out with no audio — and the clients that
+//! produce these shapes also serve no muxed format, so playback falls back to a
+//! video-only URL and the video plays silently.
+
+use flow_desktop_lib::api::innertube::extractors::player::collect_audio_tracks;
+use serde_json::{Value, json};
+
+const UA: &str = "test-agent";
+
+fn audio_format(itag: u64, mime: &str, bitrate: u64) -> Value {
+    json!({
+        "itag": itag,
+        "mimeType": mime,
+        "bitrate": bitrate,
+        "url": format!("https://rr1---sn-test.googlevideo.com/videoplayback?itag={itag}&c=VISIONOS"),
+        "initRange": { "start": "0", "end": "258" },
+        "indexRange": { "start": "259", "end": "1275" },
+    })
+}
+
+fn with_xtags(mut format: Value, xtags: &str) -> Value {
+    format["xtags"] = json!(xtags);
+    format
+}
+
+fn with_audio_track(
+    mut format: Value,
+    id: &str,
+    display: &str,
+    default: bool,
+    dubbed: bool,
+) -> Value {
+    format["audioTrack"] = json!({
+        "id": id,
+        "displayName": display,
+        "audioIsDefault": default,
+        "isAutoDubbed": dubbed,
+    });
+    format
+}
+
+fn streaming_data(formats: Vec<Value>) -> Value {
+    json!({ "adaptiveFormats": formats })
+}
+
+/// The regression: VISIONOS returns each audio itag twice — a plain copy and an
+/// `xtags` variant — with identical identity fields, so they collide on one dedup
+/// key. The higher-bitrate twin used to overwrite the entry holding the default
+/// flag, leaving a track list with no default at all.
+#[test]
+fn xtags_duplicate_of_an_itag_never_costs_the_default_flag() {
+    let data = streaming_data(vec![
+        audio_format(140, "audio/mp4; codecs=\"mp4a.40.2\"", 130_000),
+        with_xtags(
+            audio_format(140, "audio/mp4; codecs=\"mp4a.40.2\"", 260_000),
+            "Cg8KBWFjb250EgZkdWJiZWQ",
+        ),
+    ]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    assert_eq!(tracks.len(), 1, "the two copies share one identity");
+    assert!(
+        tracks[0].is_default,
+        "a track list with no default yields a manifest with no audio"
+    );
+}
+
+/// The plain twin wins even though the tagged one advertises a higher bitrate:
+/// googlevideo refuses sustained playback on the tagged variants.
+#[test]
+fn the_plain_twin_beats_the_higher_bitrate_xtags_variant() {
+    let data = streaming_data(vec![
+        with_xtags(
+            audio_format(251, "audio/webm; codecs=\"opus\"", 260_000),
+            "Cg8KBWFjb250EgZkdWJiZWQ",
+        ),
+        audio_format(251, "audio/webm; codecs=\"opus\"", 130_000),
+    ]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    assert_eq!(tracks.len(), 1);
+    assert_eq!(
+        tracks[0].bitrate,
+        Some(130_000),
+        "the untagged copy must win regardless of bitrate"
+    );
+    assert!(tracks[0].is_default);
+}
+
+/// Responses that never mention `audioTrack` at all (any video without dubs) must
+/// still produce a default rather than an unflagged list.
+#[test]
+fn a_response_with_no_audio_track_metadata_still_yields_a_default() {
+    let data = streaming_data(vec![
+        audio_format(139, "audio/mp4; codecs=\"mp4a.40.5\"", 48_000),
+        audio_format(140, "audio/mp4; codecs=\"mp4a.40.2\"", 130_000),
+        audio_format(251, "audio/webm; codecs=\"opus\"", 140_000),
+    ]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    assert_eq!(
+        tracks.iter().filter(|track| track.is_default).count(),
+        1,
+        "exactly one track must be default"
+    );
+    assert!(tracks[0].is_default, "the default sorts first");
+    assert!(tracks[0].available);
+}
+
+/// When the response *does* declare a default, that choice is authoritative — the
+/// promotion fallback must not override it or add a second one.
+#[test]
+fn a_declared_default_is_respected_over_dubbed_tracks() {
+    let data = streaming_data(vec![
+        with_audio_track(
+            audio_format(139, "audio/mp4; codecs=\"mp4a.40.5\"", 300_000),
+            "ar.10",
+            "Arabic",
+            false,
+            true,
+        ),
+        with_audio_track(
+            audio_format(251, "audio/webm; codecs=\"opus\"", 140_000),
+            "en-US.4",
+            "English (US) original",
+            true,
+            false,
+        ),
+        with_audio_track(
+            audio_format(140, "audio/mp4; codecs=\"mp4a.40.2\"", 320_000),
+            "hi.10",
+            "Hindi",
+            false,
+            true,
+        ),
+    ]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    assert_eq!(
+        tracks.iter().filter(|track| track.is_default).count(),
+        1,
+        "a dubbed track must never be promoted alongside a declared default"
+    );
+    assert_eq!(tracks[0].label, "English (US) original");
+    assert!(tracks[0].is_default);
+}
+
+/// A dubbed track must never become the default just because it is the only thing
+/// left after dedup ordering — the promotion prefers the undubbed candidate.
+#[test]
+fn promotion_prefers_an_undubbed_candidate() {
+    let data = streaming_data(vec![
+        with_audio_track(
+            audio_format(139, "audio/mp4; codecs=\"mp4a.40.5\"", 300_000),
+            "ar.10",
+            "Arabic",
+            false,
+            true,
+        ),
+        audio_format(251, "audio/webm; codecs=\"opus\"", 140_000),
+    ]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    let default = tracks
+        .iter()
+        .find(|track| track.is_default)
+        .expect("a default must exist");
+    assert_eq!(
+        default.label, "Original audio",
+        "the undubbed track is the one to promote"
+    );
+}
+
+/// Formats without a usable URL are skipped, and skipping them must not leave the
+/// remaining list without a default.
+#[test]
+fn formats_without_a_url_are_skipped_without_losing_the_default() {
+    let mut cipher_only = audio_format(140, "audio/mp4; codecs=\"mp4a.40.2\"", 130_000);
+    cipher_only["url"] = Value::Null;
+    cipher_only["signatureCipher"] = json!("s=abc&sp=sig&url=https://example.invalid/x");
+
+    let data = streaming_data(vec![
+        cipher_only,
+        audio_format(251, "audio/webm; codecs=\"opus\"", 140_000),
+    ]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    assert_eq!(tracks.len(), 1, "the cipher-only format is unusable here");
+    assert!(tracks[0].is_default);
+}
+
+#[test]
+fn every_track_carries_the_fetching_user_agent() {
+    let data = streaming_data(vec![audio_format(
+        251,
+        "audio/webm; codecs=\"opus\"",
+        140_000,
+    )]);
+
+    let tracks = collect_audio_tracks(&data, UA);
+
+    assert_eq!(
+        tracks[0].user_agent.as_deref(),
+        Some(UA),
+        "the proxy fetches audio with the UA of the client that minted the URL"
+    );
+}

--- a/src-tauri/tests/audio_tracks.rs
+++ b/src-tauri/tests/audio_tracks.rs
@@ -216,3 +216,120 @@ fn every_track_carries_the_fetching_user_agent() {
         "the proxy fetches audio with the UA of the client that minted the URL"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Dubbed-language selection
+// ---------------------------------------------------------------------------
+
+use flow_desktop_lib::api::innertube::extractors::player::select_playable_audio_tracks;
+
+/// Real VISIONOS responses, with every signed URL replaced by a placeholder.
+fn fixture(name: &str) -> Value {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name);
+    serde_json::from_str(&std::fs::read_to_string(&path).expect("fixture")).expect("valid json")
+}
+
+/// The container half of a mime type, e.g. `audio/webm` out of
+/// `audio/webm; codecs="opus"`.
+fn container_of(mime: Option<&str>) -> String {
+    mime.and_then(|mime| mime.split(';').next())
+        .unwrap_or_default()
+        .to_string()
+}
+
+#[test]
+fn every_dubbed_language_is_offered_once() {
+    let data = fixture("visionos_dubbed_streaming_data.json");
+    let selected = select_playable_audio_tracks(&collect_audio_tracks(&data, UA));
+
+    assert!(
+        selected.len() > 15,
+        "this response carries 20 languages, got {}",
+        selected.len()
+    );
+
+    let mut languages: Vec<_> = selected
+        .iter()
+        .map(|track| {
+            track
+                .language_code
+                .clone()
+                .unwrap_or_else(|| track.label.clone())
+        })
+        .collect();
+    let before = languages.len();
+    languages.sort();
+    languages.dedup();
+    assert_eq!(
+        before,
+        languages.len(),
+        "one entry per language, no duplicates"
+    );
+}
+
+/// All alternates must share a container: the manifest declares them as sibling
+/// AdaptationSets, and a container change forces the media engine to rebuild its
+/// audio source buffer mid-stream.
+#[test]
+fn all_offered_languages_share_one_container() {
+    let data = fixture("visionos_dubbed_streaming_data.json");
+    let selected = select_playable_audio_tracks(&collect_audio_tracks(&data, UA));
+
+    let mut containers: Vec<String> = selected
+        .iter()
+        .map(|track| container_of(track.mime_type.as_deref()))
+        .collect();
+    containers.sort();
+    containers.dedup();
+    assert_eq!(containers.len(), 1, "mixed containers: {containers:?}");
+}
+
+#[test]
+fn the_original_track_leads_and_stays_default() {
+    let data = fixture("visionos_dubbed_streaming_data.json");
+    let selected = select_playable_audio_tracks(&collect_audio_tracks(&data, UA));
+
+    assert!(selected[0].is_default, "the original sorts first");
+    assert!(
+        selected[0].label.contains("original"),
+        "expected the original track, got {:?}",
+        selected[0].label
+    );
+    assert_eq!(
+        selected.iter().filter(|track| track.is_default).count(),
+        1,
+        "exactly one default across all languages"
+    );
+}
+
+#[test]
+fn every_offered_track_is_playable() {
+    let data = fixture("visionos_dubbed_streaming_data.json");
+    let selected = select_playable_audio_tracks(&collect_audio_tracks(&data, UA));
+
+    for track in &selected {
+        assert!(track.available, "{} must be selectable", track.label);
+        assert!(!track.local_url.is_empty(), "{} needs a URL", track.label);
+        // The synthetic DASH manifest needs SegmentBase ranges for every rung.
+        assert!(
+            track.init_range_start.is_some() && track.index_range_start.is_some(),
+            "{} needs byte ranges to appear in the manifest",
+            track.label
+        );
+    }
+}
+
+/// A video with no dubs must still resolve to exactly one playable track — this is
+/// the shape that was playing silently before the default-flag fix.
+#[test]
+fn a_single_language_response_still_yields_one_track() {
+    let data = fixture("visionos_single_language_streaming_data.json");
+    let selected = select_playable_audio_tracks(&collect_audio_tracks(&data, UA));
+
+    assert_eq!(selected.len(), 1, "no dubs means one track");
+    assert!(selected[0].is_default);
+    assert!(selected[0].available);
+    assert!(selected[0].init_range_start.is_some());
+}

--- a/src-tauri/tests/dash_manifest.rs
+++ b/src-tauri/tests/dash_manifest.rs
@@ -1,0 +1,135 @@
+//! Guards on the synthetic DASH manifest's audio contract.
+//!
+//! The player selects a dubbed language by matching the manifest's audio
+//! AdaptationSets — by id, then `lang`, then label — and falls back to the set
+//! tagged `Role=main` when nothing is chosen. These tests lock that shape, since a
+//! manifest that drops a language or mislabels the original degrades silently:
+//! playback keeps working, just with no way to reach the other languages.
+
+use flow_desktop_lib::api::innertube::extractors::player::{
+    collect_audio_tracks, select_playable_audio_tracks,
+};
+use flow_desktop_lib::commands::youtube::build_synthetic_dash_manifest;
+use flow_desktop_lib::models::video::{StreamInfo, StreamVariant};
+use serde_json::Value;
+
+fn fixture(name: &str) -> Value {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name);
+    serde_json::from_str(&std::fs::read_to_string(&path).expect("fixture")).expect("valid json")
+}
+
+fn video_variant(height: u64, bitrate: u64) -> StreamVariant {
+    StreamVariant {
+        id: format!("video-{height}"),
+        local_url: format!("http://127.0.0.1:1/stream/video-{height}"),
+        quality_label: format!("{height}p"),
+        mime_type: Some("video/mp4; codecs=\"avc1.640028\"".to_string()),
+        width: Some(height * 16 / 9),
+        height: Some(height),
+        fps: Some(30),
+        bitrate: Some(bitrate),
+        content_length: Some(1_000_000),
+        is_default: height == 1080,
+        is_playable: true,
+        has_audio: false,
+        is_video_only: true,
+        delivery_method: "adaptive".to_string(),
+        init_range_start: Some(0),
+        init_range_end: Some(700),
+        index_range_start: Some(701),
+        index_range_end: Some(1200),
+        approx_duration_ms: Some(300_000),
+    }
+}
+
+fn stream_info_from(fixture_name: &str) -> StreamInfo {
+    let data = fixture(fixture_name);
+    let download_audio_tracks = collect_audio_tracks(&data, "test-agent");
+    let audio_tracks = select_playable_audio_tracks(&download_audio_tracks);
+    StreamInfo {
+        stream_id: "test".to_string(),
+        local_url: String::new(),
+        expires_at: "21600".to_string(),
+        variants: vec![video_variant(1080, 2_400_000), video_variant(360, 400_000)],
+        captions: Vec::new(),
+        audio_tracks,
+        download_audio_tracks,
+        hls_manifest_url: None,
+        dash_manifest_url: None,
+        is_live: false,
+        sabr: None,
+        sabr_descriptor: None,
+    }
+}
+
+#[test]
+fn every_language_becomes_its_own_adaptation_set() {
+    let info = stream_info_from("visionos_dubbed_streaming_data.json");
+    let languages = info.audio_tracks.len();
+    let manifest = build_synthetic_dash_manifest(&info).expect("a manifest");
+
+    let audio_sets = manifest.matches("contentType=\"audio\"").count();
+    assert_eq!(
+        audio_sets, languages,
+        "every offered language must reach the manifest"
+    );
+    assert!(
+        audio_sets > 15,
+        "expected the full dub list, got {audio_sets}"
+    );
+}
+
+#[test]
+fn exactly_one_audio_set_is_tagged_main() {
+    let info = stream_info_from("visionos_dubbed_streaming_data.json");
+    let manifest = build_synthetic_dash_manifest(&info).expect("a manifest");
+
+    assert_eq!(
+        manifest.matches("value=\"main\"").count(),
+        1,
+        "the player falls back to the single Role=main set when nothing is selected"
+    );
+    // The original must be the one carrying it, and it must come first.
+    let main_at = manifest.find("value=\"main\"").expect("a main role");
+    let first_alternate = manifest.find("value=\"alternate\"");
+    assert!(
+        first_alternate.is_none_or(|alternate| main_at < alternate),
+        "the original audio must precede the dubs"
+    );
+}
+
+#[test]
+fn each_audio_set_carries_a_language_and_a_unique_id() {
+    let info = stream_info_from("visionos_dubbed_streaming_data.json");
+    let manifest = build_synthetic_dash_manifest(&info).expect("a manifest");
+
+    let mut ids: Vec<&str> = manifest
+        .match_indices("<AdaptationSet id=\"audio-")
+        .map(|(index, _)| {
+            let rest = &manifest[index + "<AdaptationSet id=\"".len()..];
+            &rest[..rest.find('"').expect("closing quote")]
+        })
+        .collect();
+    let total = ids.len();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(total, ids.len(), "AdaptationSet ids must be unique");
+
+    // `lang="und"` would leave the player unable to match a track by language.
+    assert!(
+        !manifest.contains("contentType=\"audio\" lang=\"und\""),
+        "dubbed sets must declare their language"
+    );
+}
+
+#[test]
+fn a_single_language_video_still_produces_a_manifest() {
+    let info = stream_info_from("visionos_single_language_streaming_data.json");
+    let manifest = build_synthetic_dash_manifest(&info).expect("a manifest");
+
+    assert_eq!(manifest.matches("contentType=\"audio\"").count(), 1);
+    assert_eq!(manifest.matches("value=\"main\"").count(), 1);
+    assert!(manifest.contains("contentType=\"video\""));
+}

--- a/src-tauri/tests/fixtures/visionos_dubbed_streaming_data.json
+++ b/src-tauri/tests/fixtures/visionos_dubbed_streaming_data.json
@@ -1,0 +1,3894 @@
+{
+ "expiresInSeconds": "21540",
+ "adaptiveFormats": [
+  {
+   "itag": 271,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=271&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 3834356,
+   "width": 2560,
+   "height": 1440,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "1430"
+   },
+   "lastModified": "1787129712148826",
+   "contentLength": "54919009",
+   "quality": "hd1440",
+   "fps": 30,
+   "qualityLabel": "1440p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 1064752,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_1440P"
+  },
+  {
+   "itag": 400,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=400&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.12M.08\"",
+   "bitrate": 2986440,
+   "width": 2560,
+   "height": 1440,
+   "initRange": {
+    "start": "0",
+    "end": "700"
+   },
+   "indexRange": {
+    "start": "701",
+    "end": "1560"
+   },
+   "lastModified": "1787129544922695",
+   "contentLength": "36557980",
+   "quality": "hd1440",
+   "fps": 30,
+   "qualityLabel": "1440p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 708774,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_1440P"
+  },
+  {
+   "itag": 137,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=137&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.640028\"",
+   "bitrate": 2460550,
+   "width": 1920,
+   "height": 1080,
+   "initRange": {
+    "start": "0",
+    "end": "740"
+   },
+   "indexRange": {
+    "start": "741",
+    "end": "1600"
+   },
+   "lastModified": "1787129745450058",
+   "contentLength": "53248118",
+   "quality": "hd1080",
+   "fps": 30,
+   "qualityLabel": "1080p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 1032357,
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+  },
+  {
+   "itag": 248,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=248&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 1448765,
+   "width": 1920,
+   "height": 1080,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "1399"
+   },
+   "lastModified": "1787129679622166",
+   "contentLength": "19839734",
+   "quality": "hd1080",
+   "fps": 30,
+   "qualityLabel": "1080p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 384646,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+  },
+  {
+   "itag": 399,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=399&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.08M.08\"",
+   "bitrate": 1229816,
+   "width": 1920,
+   "height": 1080,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "1559"
+   },
+   "lastModified": "1787129372021466",
+   "contentLength": "16862106",
+   "quality": "hd1080",
+   "fps": 30,
+   "qualityLabel": "1080p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 326917,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+  },
+  {
+   "itag": 136,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=136&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
+   "bitrate": 1286592,
+   "width": 1280,
+   "height": 720,
+   "initRange": {
+    "start": "0",
+    "end": "739"
+   },
+   "indexRange": {
+    "start": "740",
+    "end": "1599"
+   },
+   "lastModified": "1787129560131585",
+   "contentLength": "31363112",
+   "quality": "hd720",
+   "fps": 30,
+   "qualityLabel": "720p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 608058,
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_720P"
+  },
+  {
+   "itag": 247,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=247&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 1030644,
+   "width": 1280,
+   "height": 720,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "1385"
+   },
+   "lastModified": "1787129575451316",
+   "contentLength": "14094666",
+   "quality": "hd720",
+   "fps": 30,
+   "qualityLabel": "720p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 273262,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_720P"
+  },
+  {
+   "itag": 398,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=398&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.05M.08\"",
+   "bitrate": 764345,
+   "width": 1280,
+   "height": 720,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "1559"
+   },
+   "lastModified": "1787129336104219",
+   "contentLength": "10461736",
+   "quality": "hd720",
+   "fps": 30,
+   "qualityLabel": "720p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 202828,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_720P"
+  },
+  {
+   "itag": 135,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=135&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
+   "bitrate": 744638,
+   "width": 854,
+   "height": 480,
+   "initRange": {
+    "start": "0",
+    "end": "740"
+   },
+   "indexRange": {
+    "start": "741",
+    "end": "1600"
+   },
+   "lastModified": "1787129620757463",
+   "contentLength": "17836151",
+   "quality": "large",
+   "fps": 30,
+   "qualityLabel": "480p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 345801,
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_480P"
+  },
+  {
+   "itag": 244,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=244&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 592802,
+   "width": 854,
+   "height": 480,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "1385"
+   },
+   "lastModified": "1787129309558936",
+   "contentLength": "7651217",
+   "quality": "large",
+   "fps": 30,
+   "qualityLabel": "480p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 148339,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_480P"
+  },
+  {
+   "itag": 397,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=397&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.04M.08\"",
+   "bitrate": 451741,
+   "width": 854,
+   "height": 480,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "1559"
+   },
+   "lastModified": "1787129358861608",
+   "contentLength": "6067540",
+   "quality": "large",
+   "fps": 30,
+   "qualityLabel": "480p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 117635,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_480P"
+  },
+  {
+   "itag": 134,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=134&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d401e\"",
+   "bitrate": 371669,
+   "width": 640,
+   "height": 360,
+   "initRange": {
+    "start": "0",
+    "end": "740"
+   },
+   "indexRange": {
+    "start": "741",
+    "end": "1600"
+   },
+   "lastModified": "1787129545785474",
+   "contentLength": "9265036",
+   "quality": "medium",
+   "fps": 30,
+   "qualityLabel": "360p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 179627,
+   "highReplication": true,
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_360P"
+  },
+  {
+   "itag": 243,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=243&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 340249,
+   "width": 640,
+   "height": 360,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "1385"
+   },
+   "lastModified": "1787129536116466",
+   "contentLength": "4799989",
+   "quality": "medium",
+   "fps": 30,
+   "qualityLabel": "360p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 93060,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_360P"
+  },
+  {
+   "itag": 396,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=396&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.01M.08\"",
+   "bitrate": 265241,
+   "width": 640,
+   "height": 360,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "1559"
+   },
+   "lastModified": "1787129537285427",
+   "contentLength": "3833393",
+   "quality": "medium",
+   "fps": 30,
+   "qualityLabel": "360p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 74320,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_360P"
+  },
+  {
+   "itag": 133,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=133&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d4015\"",
+   "bitrate": 277448,
+   "width": 426,
+   "height": 240,
+   "initRange": {
+    "start": "0",
+    "end": "739"
+   },
+   "indexRange": {
+    "start": "740",
+    "end": "1599"
+   },
+   "lastModified": "1787129559016752",
+   "contentLength": "12761529",
+   "quality": "small",
+   "fps": 30,
+   "qualityLabel": "240p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 247416,
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_240P"
+  },
+  {
+   "itag": 242,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=242&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 195766,
+   "width": 426,
+   "height": 240,
+   "initRange": {
+    "start": "0",
+    "end": "218"
+   },
+   "indexRange": {
+    "start": "219",
+    "end": "1383"
+   },
+   "lastModified": "1787129712765081",
+   "contentLength": "2761580",
+   "quality": "small",
+   "fps": 30,
+   "qualityLabel": "240p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 53540,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_240P"
+  },
+  {
+   "itag": 395,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=395&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+   "bitrate": 152852,
+   "width": 426,
+   "height": 240,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "1559"
+   },
+   "lastModified": "1787129504209926",
+   "contentLength": "2215025",
+   "quality": "small",
+   "fps": 30,
+   "qualityLabel": "240p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 42944,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_240P"
+  },
+  {
+   "itag": 160,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=160&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d400c\"",
+   "bitrate": 130026,
+   "width": 256,
+   "height": 144,
+   "initRange": {
+    "start": "0",
+    "end": "738"
+   },
+   "indexRange": {
+    "start": "739",
+    "end": "1598"
+   },
+   "lastModified": "1787129614040051",
+   "contentLength": "5789292",
+   "quality": "tiny",
+   "fps": 30,
+   "qualityLabel": "144p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 112240,
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_144P"
+  },
+  {
+   "itag": 278,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=278&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 112198,
+   "width": 256,
+   "height": 144,
+   "initRange": {
+    "start": "0",
+    "end": "218"
+   },
+   "indexRange": {
+    "start": "219",
+    "end": "1383"
+   },
+   "lastModified": "1787129319599358",
+   "contentLength": "2318582",
+   "quality": "tiny",
+   "fps": 30,
+   "qualityLabel": "144p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 44951,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_144P"
+  },
+  {
+   "itag": 394,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=394&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+   "bitrate": 80517,
+   "width": 256,
+   "height": 144,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "1559"
+   },
+   "lastModified": "1787129509830887",
+   "contentLength": "1366053",
+   "quality": "tiny",
+   "fps": 30,
+   "qualityLabel": "144p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 26484,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "412633",
+   "qualityOrdinal": "QUALITY_ORDINAL_144P"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50074,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117051536415",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJhcg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Arabic",
+    "id": "ar.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50103,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117039416500",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJibg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Bangla",
+    "id": "bn.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50322,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787123700823904",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVkZS1ERQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "German (DE)",
+    "id": "de-DE.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50220,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787151622716340",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVlcy1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Spanish (US)",
+    "id": "es-US.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.6199999,
+   "trackAbsoluteLoudnessLkfs": -15.62,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50292,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787127799217916",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVmci1GUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "French (FR)",
+    "id": "fr-FR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.9799995,
+   "trackAbsoluteLoudnessLkfs": -15.98,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50279,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787147076486107",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJoaQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hindi",
+    "id": "hi.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50168,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787143972343084",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Italian",
+    "id": "it.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.7399998,
+   "trackAbsoluteLoudnessLkfs": -16.74,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50156,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117035572851",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hebrew",
+    "id": "iw.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.1399994,
+   "trackAbsoluteLoudnessLkfs": -16.14,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50188,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117164161166",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJqYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Japanese",
+    "id": "ja.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.5500002,
+   "trackAbsoluteLoudnessLkfs": -15.55,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50131,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117056946751",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJrbw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Korean",
+    "id": "ko.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2,
+   "trackAbsoluteLoudnessLkfs": -16,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50080,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117099095909",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJtbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Malayalam",
+    "id": "ml.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50224,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117041210207",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVubC1OTA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Dutch (NL)",
+    "id": "nl-NL.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.540001,
+   "trackAbsoluteLoudnessLkfs": -16.54,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50160,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117040028670",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Punjabi",
+    "id": "pa.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.5200005,
+   "trackAbsoluteLoudnessLkfs": -16.52,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50158,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117097452293",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Polish",
+    "id": "pl.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.6999998,
+   "trackAbsoluteLoudnessLkfs": -15.7,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50134,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787135687469285",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVwdC1CUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Portuguese (BR)",
+    "id": "pt-BR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50233,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117064044689",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJydQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Russian",
+    "id": "ru.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.209999,
+   "trackAbsoluteLoudnessLkfs": -16.21,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50136,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117077374222",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0YQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Tamil",
+    "id": "ta.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.040001,
+   "trackAbsoluteLoudnessLkfs": -16.04,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50063,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117067576680",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0ZQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Telugu",
+    "id": "te.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50092,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117065089035",
+   "contentLength": "2518300",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ1aw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Ukrainian",
+    "id": "uk.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48798,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412850",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -2.25,
+   "trackAbsoluteLoudnessLkfs": -16.25,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50172,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1267"
+   },
+   "lastModified": "1787117023278237",
+   "contentLength": "2518096",
+   "quality": "tiny",
+   "xtags": "ChEKBWFjb250EghvcmlnaW5hbAoNCgRsYW5nEgVlbi1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "English (US) original",
+    "id": "en-US.4",
+    "audioIsDefault": true
+   },
+   "averageBitrate": 48805,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412757",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -0.020000458,
+   "trackAbsoluteLoudnessLkfs": -14.02,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130591,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117051546691",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJhcg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Arabic",
+    "id": "ar.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130655,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117039223759",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJibg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Bangla",
+    "id": "bn.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130716,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787123703480067",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVkZS1ERQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "German (DE)",
+    "id": "de-DE.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130610,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787151621542062",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVlcy1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Spanish (US)",
+    "id": "es-US.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.6199999,
+   "trackAbsoluteLoudnessLkfs": -15.62,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130631,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787127798962396",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVmci1GUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "French (FR)",
+    "id": "fr-FR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.9799995,
+   "trackAbsoluteLoudnessLkfs": -15.98,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130673,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787147076148945",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJoaQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hindi",
+    "id": "hi.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130735,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787143971262337",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Italian",
+    "id": "it.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.7399998,
+   "trackAbsoluteLoudnessLkfs": -16.74,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130684,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117035547459",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hebrew",
+    "id": "iw.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.1399994,
+   "trackAbsoluteLoudnessLkfs": -16.14,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130654,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117164305259",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJqYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Japanese",
+    "id": "ja.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.5500002,
+   "trackAbsoluteLoudnessLkfs": -15.55,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130622,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117056485446",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJrbw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Korean",
+    "id": "ko.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2,
+   "trackAbsoluteLoudnessLkfs": -16,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130735,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117099393968",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJtbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Malayalam",
+    "id": "ml.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130728,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117043356750",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVubC1OTA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Dutch (NL)",
+    "id": "nl-NL.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.540001,
+   "trackAbsoluteLoudnessLkfs": -16.54,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130655,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117040465352",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Punjabi",
+    "id": "pa.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.5200005,
+   "trackAbsoluteLoudnessLkfs": -16.52,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130635,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117097767832",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Polish",
+    "id": "pl.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.6999998,
+   "trackAbsoluteLoudnessLkfs": -15.7,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130760,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787135686747455",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVwdC1CUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Portuguese (BR)",
+    "id": "pt-BR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130626,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117064223901",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJydQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Russian",
+    "id": "ru.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.209999,
+   "trackAbsoluteLoudnessLkfs": -16.21,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130626,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117077060813",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0YQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Tamil",
+    "id": "ta.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.040001,
+   "trackAbsoluteLoudnessLkfs": -16.04,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130530,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117069121674",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0ZQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Telugu",
+    "id": "te.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130694,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117065666426",
+   "contentLength": "6681233",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ1aw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Ukrainian",
+    "id": "uk.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412781",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -2.25,
+   "trackAbsoluteLoudnessLkfs": -16.25,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130603,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1258"
+   },
+   "lastModified": "1787117023278956",
+   "contentLength": "6679731",
+   "quality": "tiny",
+   "xtags": "ChEKBWFjb250EghvcmlnaW5hbAoNCgRsYW5nEgVlbi1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "English (US) original",
+    "id": "en-US.4",
+    "audioIsDefault": true
+   },
+   "averageBitrate": 129487,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412688",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -0.020000458,
+   "trackAbsoluteLoudnessLkfs": -14.02,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52137,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117043350275",
+   "contentLength": "2611103",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJhcg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Arabic",
+    "id": "ar.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50607,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51228,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117068361562",
+   "contentLength": "2571287",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJibg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Bangla",
+    "id": "bn.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 49835,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51251,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787123786880588",
+   "contentLength": "2512159",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVkZS1ERQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "German (DE)",
+    "id": "de-DE.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48689,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51393,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787151614352244",
+   "contentLength": "2528375",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVlcy1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Spanish (US)",
+    "id": "es-US.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 49004,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.6199999,
+   "trackAbsoluteLoudnessLkfs": -15.62,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52021,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787128204744876",
+   "contentLength": "2514940",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVmci1GUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "French (FR)",
+    "id": "fr-FR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48743,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52048,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787147129428453",
+   "contentLength": "2546788",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJoaQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hindi",
+    "id": "hi.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 49361,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51068,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787144005999826",
+   "contentLength": "2522540",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Italian",
+    "id": "it.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48891,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.7399998,
+   "trackAbsoluteLoudnessLkfs": -16.74,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52177,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117061396201",
+   "contentLength": "2629744",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hebrew",
+    "id": "iw.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50968,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.1499996,
+   "trackAbsoluteLoudnessLkfs": -16.15,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51673,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117188366697",
+   "contentLength": "2564652",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJqYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Japanese",
+    "id": "ja.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 49707,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.5500002,
+   "trackAbsoluteLoudnessLkfs": -15.55,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52386,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117092075996",
+   "contentLength": "2580518",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJrbw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Korean",
+    "id": "ko.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50014,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2,
+   "trackAbsoluteLoudnessLkfs": -16,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52505,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117126848911",
+   "contentLength": "2596750",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJtbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Malayalam",
+    "id": "ml.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50329,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52276,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117059341873",
+   "contentLength": "2609901",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVubC1OTA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Dutch (NL)",
+    "id": "nl-NL.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50584,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.540001,
+   "trackAbsoluteLoudnessLkfs": -16.54,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51508,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117053952817",
+   "contentLength": "2586153",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Punjabi",
+    "id": "pa.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50123,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.5200005,
+   "trackAbsoluteLoudnessLkfs": -16.52,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52953,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117092995182",
+   "contentLength": "2642482",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Polish",
+    "id": "pl.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 51215,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51782,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787135729275147",
+   "contentLength": "2525683",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVwdC1CUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Portuguese (BR)",
+    "id": "pt-BR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 48951,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51678,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117094616044",
+   "contentLength": "2598729",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJydQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Russian",
+    "id": "ru.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50367,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2199993,
+   "trackAbsoluteLoudnessLkfs": -16.22,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52071,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117100297938",
+   "contentLength": "2621045",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0YQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Tamil",
+    "id": "ta.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 50800,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.040001,
+   "trackAbsoluteLoudnessLkfs": -16.04,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 51137,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "968"
+   },
+   "lastModified": "1787117072213757",
+   "contentLength": "2555628",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0ZQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Telugu",
+    "id": "te.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 49532,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52673,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117083412331",
+   "contentLength": "2636527",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ1aw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Ukrainian",
+    "id": "uk.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 51100,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 52846,
+   "initRange": {
+    "start": "0",
+    "end": "265"
+   },
+   "indexRange": {
+    "start": "266",
+    "end": "976"
+   },
+   "lastModified": "1787117041193134",
+   "contentLength": "2669398",
+   "quality": "tiny",
+   "xtags": "ChEKBWFjb250EghvcmlnaW5hbAoNCgRsYW5nEgVlbi1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "English (US) original",
+    "id": "en-US.4",
+    "audioIsDefault": true
+   },
+   "averageBitrate": 51752,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412641",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -0.020000458,
+   "trackAbsoluteLoudnessLkfs": -14.02,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 73417,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117043470631",
+   "contentLength": "3615433",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJhcg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Arabic",
+    "id": "ar.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 70073,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 74802,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117066232679",
+   "contentLength": "3626475",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJibg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Bangla",
+    "id": "bn.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 70287,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 78064,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787123786597722",
+   "contentLength": "3806267",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVkZS1ERQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "German (DE)",
+    "id": "de-DE.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 73771,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 77585,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787151614639409",
+   "contentLength": "3773463",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVlcy1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Spanish (US)",
+    "id": "es-US.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 73136,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.6199999,
+   "trackAbsoluteLoudnessLkfs": -15.62,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 76692,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787128204570849",
+   "contentLength": "3703542",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVmci1GUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "French (FR)",
+    "id": "fr-FR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 71780,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 76752,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787147129473227",
+   "contentLength": "3781554",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJoaQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hindi",
+    "id": "hi.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 73292,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 78059,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787144003329708",
+   "contentLength": "3792625",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Italian",
+    "id": "it.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 73507,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.7399998,
+   "trackAbsoluteLoudnessLkfs": -16.74,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 70701,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117061227328",
+   "contentLength": "3469674",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hebrew",
+    "id": "iw.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 67248,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.1499996,
+   "trackAbsoluteLoudnessLkfs": -16.15,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 73020,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117188184841",
+   "contentLength": "3582001",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJqYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Japanese",
+    "id": "ja.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 69425,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.5500002,
+   "trackAbsoluteLoudnessLkfs": -15.55,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 72899,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117092209852",
+   "contentLength": "3600299",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJrbw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Korean",
+    "id": "ko.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 69779,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2,
+   "trackAbsoluteLoudnessLkfs": -16,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 76090,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117126205729",
+   "contentLength": "3681285",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJtbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Malayalam",
+    "id": "ml.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 71349,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 72092,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117060577217",
+   "contentLength": "3521837",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVubC1OTA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Dutch (NL)",
+    "id": "nl-NL.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 68259,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.540001,
+   "trackAbsoluteLoudnessLkfs": -16.54,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 73983,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117053594115",
+   "contentLength": "3592196",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Punjabi",
+    "id": "pa.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 69622,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.5200005,
+   "trackAbsoluteLoudnessLkfs": -16.52,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 74386,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117093329153",
+   "contentLength": "3614766",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Polish",
+    "id": "pl.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 70060,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 77746,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787135731159657",
+   "contentLength": "3715682",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVwdC1CUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Portuguese (BR)",
+    "id": "pt-BR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 72016,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 71974,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117093747024",
+   "contentLength": "3551249",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJydQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Russian",
+    "id": "ru.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 68829,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2199993,
+   "trackAbsoluteLoudnessLkfs": -16.22,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 74287,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117100665217",
+   "contentLength": "3671237",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0YQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Tamil",
+    "id": "ta.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 71154,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.040001,
+   "trackAbsoluteLoudnessLkfs": -16.04,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 76810,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117073411149",
+   "contentLength": "3626366",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0ZQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Telugu",
+    "id": "te.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 70285,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 74752,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117083538620",
+   "contentLength": "3675745",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ1aw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Ukrainian",
+    "id": "uk.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 71242,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 74464,
+   "initRange": {
+    "start": "0",
+    "end": "265"
+   },
+   "indexRange": {
+    "start": "266",
+    "end": "976"
+   },
+   "lastModified": "1787117041219768",
+   "contentLength": "3672756",
+   "quality": "tiny",
+   "xtags": "ChEKBWFjb250EghvcmlnaW5hbAoNCgRsYW5nEgVlbi1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "English (US) original",
+    "id": "en-US.4",
+    "audioIsDefault": true
+   },
+   "averageBitrate": 71204,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "412641",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -0.020000458,
+   "trackAbsoluteLoudnessLkfs": -14.02,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 131094,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117043295241",
+   "contentLength": "6468927",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJhcg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Arabic",
+    "id": "ar.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 125378,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 132416,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117066727790",
+   "contentLength": "6436942",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJibg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Bangla",
+    "id": "bn.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 124758,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.33,
+   "trackAbsoluteLoudnessLkfs": -16.33,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 139702,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787123786607320",
+   "contentLength": "6856741",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVkZS1ERQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "German (DE)",
+    "id": "de-DE.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 132895,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 139194,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787151614692191",
+   "contentLength": "6802478",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVlcy1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Spanish (US)",
+    "id": "es-US.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 131843,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.6199999,
+   "trackAbsoluteLoudnessLkfs": -15.62,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 137509,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787128204915907",
+   "contentLength": "6658958",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVmci1GUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "French (FR)",
+    "id": "fr-FR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129061,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 138023,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787147129471701",
+   "contentLength": "6821986",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJoaQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hindi",
+    "id": "hi.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 132221,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9899998,
+   "trackAbsoluteLoudnessLkfs": -15.99,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 141047,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787144003496756",
+   "contentLength": "6843170",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Italian",
+    "id": "it.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 132632,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.7399998,
+   "trackAbsoluteLoudnessLkfs": -16.74,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 126043,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117062308916",
+   "contentLength": "6201049",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJpdw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Hebrew",
+    "id": "iw.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 120186,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.1499996,
+   "trackAbsoluteLoudnessLkfs": -16.15,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 129352,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117187212205",
+   "contentLength": "6370781",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJqYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Japanese",
+    "id": "ja.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 123476,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.5500002,
+   "trackAbsoluteLoudnessLkfs": -15.55,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 129363,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117092045446",
+   "contentLength": "6433416",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJrbw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Korean",
+    "id": "ko.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 124690,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2,
+   "trackAbsoluteLoudnessLkfs": -16,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 134568,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117126857611",
+   "contentLength": "6550160",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJtbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Malayalam",
+    "id": "ml.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 126953,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 127771,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117059703055",
+   "contentLength": "6270739",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVubC1OTA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Dutch (NL)",
+    "id": "nl-NL.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 121537,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.540001,
+   "trackAbsoluteLoudnessLkfs": -16.54,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 131011,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117053696804",
+   "contentLength": "6400720",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwYQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Punjabi",
+    "id": "pa.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 124056,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.5200005,
+   "trackAbsoluteLoudnessLkfs": -16.52,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 132985,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117093107907",
+   "contentLength": "6456963",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJwbA",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Polish",
+    "id": "pl.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 125146,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 138676,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787135729100663",
+   "contentLength": "6690033",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoNCgRsYW5nEgVwdC1CUg",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Portuguese (BR)",
+    "id": "pt-BR.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 129664,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.71,
+   "trackAbsoluteLoudnessLkfs": -15.71,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 128324,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117092638318",
+   "contentLength": "6331397",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJydQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Russian",
+    "id": "ru.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 122713,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2199993,
+   "trackAbsoluteLoudnessLkfs": -16.22,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 131864,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117100274955",
+   "contentLength": "6519065",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0YQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Tamil",
+    "id": "ta.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 126350,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.040001,
+   "trackAbsoluteLoudnessLkfs": -16.04,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 136903,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117072216965",
+   "contentLength": "6465485",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ0ZQ",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Telugu",
+    "id": "te.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 125311,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.9099998,
+   "trackAbsoluteLoudnessLkfs": -15.91,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 133450,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "969"
+   },
+   "lastModified": "1787117083935452",
+   "contentLength": "6554309",
+   "quality": "tiny",
+   "xtags": "ChQKBWFjb250EgtkdWJiZWQtYXV0bwoKCgRsYW5nEgJ1aw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "Ukrainian",
+    "id": "uk.10",
+    "audioIsDefault": false,
+    "isAutoDubbed": true
+   },
+   "averageBitrate": 127033,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412761",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -2.2600002,
+   "trackAbsoluteLoudnessLkfs": -16.26,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 136954,
+   "initRange": {
+    "start": "0",
+    "end": "265"
+   },
+   "indexRange": {
+    "start": "266",
+    "end": "976"
+   },
+   "lastModified": "1787117041281146",
+   "contentLength": "6772026",
+   "quality": "tiny",
+   "xtags": "ChEKBWFjb250EghvcmlnaW5hbAoNCgRsYW5nEgVlbi1VUw",
+   "projectionType": "RECTANGULAR",
+   "audioTrack": {
+    "displayName": "English (US) original",
+    "id": "en-US.4",
+    "audioIsDefault": true
+   },
+   "averageBitrate": 131291,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "412641",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -0.020000458,
+   "trackAbsoluteLoudnessLkfs": -14.02,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  }
+ ],
+ "hlsManifestUrl": "https://redacted.youtube.com/manifest.m3u8",
+ "aspectRatio": 1.7777778,
+ "serverAbrStreamingUrl": "https://redacted.googlevideo.com/videoplayback?redacted=1"
+}

--- a/src-tauri/tests/fixtures/visionos_single_language_streaming_data.json
+++ b/src-tauri/tests/fixtures/visionos_single_language_streaming_data.json
@@ -1,0 +1,911 @@
+{
+ "expiresInSeconds": "21540",
+ "adaptiveFormats": [
+  {
+   "itag": 313,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=313&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 17845200,
+   "width": 3840,
+   "height": 2160,
+   "initRange": {
+    "start": "0",
+    "end": "220"
+   },
+   "indexRange": {
+    "start": "221",
+    "end": "2225"
+   },
+   "lastModified": "1785023894724999",
+   "contentLength": "1157418410",
+   "quality": "hd2160",
+   "fps": 30,
+   "qualityLabel": "2160p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 15594243,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_2160P"
+  },
+  {
+   "itag": 401,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=401&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.12M.08\"",
+   "bitrate": 16996742,
+   "width": 3840,
+   "height": 2160,
+   "initRange": {
+    "start": "0",
+    "end": "700"
+   },
+   "indexRange": {
+    "start": "701",
+    "end": "2076"
+   },
+   "lastModified": "1785019896492371",
+   "contentLength": "752122474",
+   "quality": "hd2160",
+   "fps": 30,
+   "qualityLabel": "2160p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 10133587,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_2160P"
+  },
+  {
+   "itag": 271,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=271&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 8920059,
+   "width": 2560,
+   "height": 1440,
+   "initRange": {
+    "start": "0",
+    "end": "220"
+   },
+   "indexRange": {
+    "start": "221",
+    "end": "2222"
+   },
+   "lastModified": "1785018771467009",
+   "contentLength": "474434101",
+   "quality": "hd1440",
+   "fps": 30,
+   "qualityLabel": "1440p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 6392192,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_1440P"
+  },
+  {
+   "itag": 400,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=400&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.12M.08\"",
+   "bitrate": 7835404,
+   "width": 2560,
+   "height": 1440,
+   "initRange": {
+    "start": "0",
+    "end": "700"
+   },
+   "indexRange": {
+    "start": "701",
+    "end": "2076"
+   },
+   "lastModified": "1785020459051403",
+   "contentLength": "371010236",
+   "quality": "hd1440",
+   "fps": 30,
+   "qualityLabel": "1440p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 4998740,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_1440P"
+  },
+  {
+   "itag": 137,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=137&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.640028\"",
+   "bitrate": 4340915,
+   "width": 1920,
+   "height": 1080,
+   "initRange": {
+    "start": "0",
+    "end": "741"
+   },
+   "indexRange": {
+    "start": "742",
+    "end": "2117"
+   },
+   "lastModified": "1785017490167084",
+   "contentLength": "227772848",
+   "quality": "hd1080",
+   "fps": 30,
+   "qualityLabel": "1080p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 3068856,
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+  },
+  {
+   "itag": 248,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=248&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 2903382,
+   "width": 1920,
+   "height": 1080,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "2210"
+   },
+   "lastModified": "1785019391328849",
+   "contentLength": "140682337",
+   "quality": "hd1080",
+   "fps": 30,
+   "qualityLabel": "1080p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 1895455,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+  },
+  {
+   "itag": 399,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=399&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.08M.08\"",
+   "bitrate": 2091216,
+   "width": 1920,
+   "height": 1080,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "2075"
+   },
+   "lastModified": "1785020027330755",
+   "contentLength": "113927729",
+   "quality": "hd1080",
+   "fps": 30,
+   "qualityLabel": "1080p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 1534984,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_1080P"
+  },
+  {
+   "itag": 136,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=136&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
+   "bitrate": 1957128,
+   "width": 1280,
+   "height": 720,
+   "initRange": {
+    "start": "0",
+    "end": "739"
+   },
+   "indexRange": {
+    "start": "740",
+    "end": "2115"
+   },
+   "lastModified": "1785016735785801",
+   "contentLength": "79204930",
+   "quality": "hd720",
+   "fps": 30,
+   "qualityLabel": "720p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 1067153,
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_720P"
+  },
+  {
+   "itag": 247,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=247&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 1649226,
+   "width": 1280,
+   "height": 720,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "2200"
+   },
+   "lastModified": "1785024411037510",
+   "contentLength": "86221013",
+   "quality": "hd720",
+   "fps": 30,
+   "qualityLabel": "720p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 1161681,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_720P"
+  },
+  {
+   "itag": 398,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=398&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.05M.08\"",
+   "bitrate": 1169578,
+   "width": 1280,
+   "height": 720,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "2075"
+   },
+   "lastModified": "1785018878091065",
+   "contentLength": "59397579",
+   "quality": "hd720",
+   "fps": 30,
+   "qualityLabel": "720p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 800282,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_720P"
+  },
+  {
+   "itag": 135,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=135&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d401f\"",
+   "bitrate": 1162306,
+   "width": 854,
+   "height": 480,
+   "initRange": {
+    "start": "0",
+    "end": "740"
+   },
+   "indexRange": {
+    "start": "741",
+    "end": "2116"
+   },
+   "lastModified": "1785016875026059",
+   "contentLength": "47020619",
+   "quality": "large",
+   "fps": 30,
+   "qualityLabel": "480p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 633523,
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_480P"
+  },
+  {
+   "itag": 244,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=244&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 793028,
+   "width": 854,
+   "height": 480,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "2181"
+   },
+   "lastModified": "1785024408313151",
+   "contentLength": "42732250",
+   "quality": "large",
+   "fps": 30,
+   "qualityLabel": "480p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 575744,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_480P"
+  },
+  {
+   "itag": 397,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=397&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.04M.08\"",
+   "bitrate": 586978,
+   "width": 854,
+   "height": 480,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "2075"
+   },
+   "lastModified": "1785018406448308",
+   "contentLength": "31266060",
+   "quality": "large",
+   "fps": 30,
+   "qualityLabel": "480p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 421257,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_480P"
+  },
+  {
+   "itag": 134,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=134&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d401e\"",
+   "bitrate": 639225,
+   "width": 640,
+   "height": 360,
+   "initRange": {
+    "start": "0",
+    "end": "740"
+   },
+   "indexRange": {
+    "start": "741",
+    "end": "2116"
+   },
+   "lastModified": "1785016646259874",
+   "contentLength": "26893949",
+   "quality": "medium",
+   "fps": 30,
+   "qualityLabel": "360p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 362350,
+   "highReplication": true,
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_360P"
+  },
+  {
+   "itag": 243,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=243&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 462651,
+   "width": 640,
+   "height": 360,
+   "initRange": {
+    "start": "0",
+    "end": "219"
+   },
+   "indexRange": {
+    "start": "220",
+    "end": "2156"
+   },
+   "lastModified": "1785024408043519",
+   "contentLength": "25708528",
+   "quality": "medium",
+   "fps": 30,
+   "qualityLabel": "360p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 346378,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_360P"
+  },
+  {
+   "itag": 396,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=396&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.01M.08\"",
+   "bitrate": 316379,
+   "width": 640,
+   "height": 360,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "2075"
+   },
+   "lastModified": "1785017842253531",
+   "contentLength": "17478039",
+   "quality": "medium",
+   "fps": 30,
+   "qualityLabel": "360p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 235487,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_360P"
+  },
+  {
+   "itag": 133,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=133&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d4015\"",
+   "bitrate": 248491,
+   "width": 426,
+   "height": 240,
+   "initRange": {
+    "start": "0",
+    "end": "739"
+   },
+   "indexRange": {
+    "start": "740",
+    "end": "2115"
+   },
+   "lastModified": "1785016702287889",
+   "contentLength": "13092268",
+   "quality": "small",
+   "fps": 30,
+   "qualityLabel": "240p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 176396,
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_240P"
+  },
+  {
+   "itag": 242,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=242&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 211790,
+   "width": 426,
+   "height": 240,
+   "initRange": {
+    "start": "0",
+    "end": "218"
+   },
+   "indexRange": {
+    "start": "219",
+    "end": "2112"
+   },
+   "lastModified": "1785024375889621",
+   "contentLength": "11390021",
+   "quality": "small",
+   "fps": 30,
+   "qualityLabel": "240p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 153461,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_240P"
+  },
+  {
+   "itag": 395,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=395&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+   "bitrate": 155537,
+   "width": 426,
+   "height": 240,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "2075"
+   },
+   "lastModified": "1785016859589081",
+   "contentLength": "8369230",
+   "quality": "small",
+   "fps": 30,
+   "qualityLabel": "240p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 112761,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_240P"
+  },
+  {
+   "itag": 160,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=160&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"avc1.4d400c\"",
+   "bitrate": 111330,
+   "width": 256,
+   "height": 144,
+   "initRange": {
+    "start": "0",
+    "end": "738"
+   },
+   "indexRange": {
+    "start": "739",
+    "end": "2114"
+   },
+   "lastModified": "1785016669571333",
+   "contentLength": "5919538",
+   "quality": "tiny",
+   "fps": 30,
+   "qualityLabel": "144p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 79755,
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_144P"
+  },
+  {
+   "itag": 278,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=278&c=VISIONOS",
+   "mimeType": "video/webm; codecs=\"vp9\"",
+   "bitrate": 94160,
+   "width": 256,
+   "height": 144,
+   "initRange": {
+    "start": "0",
+    "end": "218"
+   },
+   "indexRange": {
+    "start": "219",
+    "end": "2112"
+   },
+   "lastModified": "1785024407034924",
+   "contentLength": "5292836",
+   "quality": "tiny",
+   "fps": 30,
+   "qualityLabel": "144p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 71311,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593767",
+   "qualityOrdinal": "QUALITY_ORDINAL_144P"
+  },
+  {
+   "itag": 394,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=394&c=VISIONOS",
+   "mimeType": "video/mp4; codecs=\"av01.0.00M.08\"",
+   "bitrate": 83985,
+   "width": 256,
+   "height": 144,
+   "initRange": {
+    "start": "0",
+    "end": "699"
+   },
+   "indexRange": {
+    "start": "700",
+    "end": "2075"
+   },
+   "lastModified": "1785017953954594",
+   "contentLength": "4552376",
+   "quality": "tiny",
+   "fps": 30,
+   "qualityLabel": "144p",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 61335,
+   "colorInfo": {
+    "primaries": "COLOR_PRIMARIES_BT709",
+    "transferCharacteristics": "COLOR_TRANSFER_CHARACTERISTICS_BT709",
+    "matrixCoefficients": "COLOR_MATRIX_COEFFICIENTS_BT709"
+   },
+   "approxDurationMs": "593766",
+   "qualityOrdinal": "QUALITY_ORDINAL_144P"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50223,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1483"
+   },
+   "lastModified": "1785014333033136",
+   "contentLength": "3622388",
+   "quality": "tiny",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 48796,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "593873",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": 1.1199999,
+   "trackAbsoluteLoudnessLkfs": -12.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 139,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=139&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.5\"",
+   "bitrate": 50228,
+   "initRange": {
+    "start": "0",
+    "end": "731"
+   },
+   "indexRange": {
+    "start": "732",
+    "end": "1483"
+   },
+   "lastModified": "1785014406788348",
+   "contentLength": "3622401",
+   "quality": "tiny",
+   "xtags": "CggKA2RyYxIBMQ",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 48796,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "593873",
+   "audioSampleRate": "22050",
+   "audioChannels": 2,
+   "loudnessDb": -1.8800001,
+   "isDrc": true,
+   "trackAbsoluteLoudnessLkfs": -15.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130942,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1474"
+   },
+   "lastModified": "1785014332931090",
+   "contentLength": "9611244",
+   "quality": "tiny",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 129482,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "593827",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": 1.1199999,
+   "trackAbsoluteLoudnessLkfs": -12.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 140,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=140&c=VISIONOS",
+   "mimeType": "audio/mp4; codecs=\"mp4a.40.2\"",
+   "bitrate": 130950,
+   "initRange": {
+    "start": "0",
+    "end": "722"
+   },
+   "indexRange": {
+    "start": "723",
+    "end": "1474"
+   },
+   "lastModified": "1785014409978342",
+   "contentLength": "9611244",
+   "quality": "tiny",
+   "xtags": "CggKA2RyYxIBMQ",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 129482,
+   "highReplication": true,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "593827",
+   "audioSampleRate": "44100",
+   "audioChannels": 2,
+   "loudnessDb": -1.8800001,
+   "isDrc": true,
+   "trackAbsoluteLoudnessLkfs": -15.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 54955,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "1275"
+   },
+   "lastModified": "1785014348974116",
+   "contentLength": "3557181",
+   "quality": "tiny",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 47925,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "593781",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": 1.1099997,
+   "trackAbsoluteLoudnessLkfs": -12.89,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 249,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=249&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 54880,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "1275"
+   },
+   "lastModified": "1785014393833200",
+   "contentLength": "3561379",
+   "quality": "tiny",
+   "xtags": "CggKA2RyYxIBMQ",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 47982,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "593781",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.8800001,
+   "isDrc": true,
+   "trackAbsoluteLoudnessLkfs": -15.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 69860,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "1275"
+   },
+   "lastModified": "1785014348528278",
+   "contentLength": "4333409",
+   "quality": "tiny",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 58383,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "593781",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": 1.1099997,
+   "trackAbsoluteLoudnessLkfs": -12.89,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 250,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=250&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 70252,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "1275"
+   },
+   "lastModified": "1785014393912195",
+   "contentLength": "4348034",
+   "quality": "tiny",
+   "xtags": "CggKA2RyYxIBMQ",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 58580,
+   "audioQuality": "AUDIO_QUALITY_LOW",
+   "approxDurationMs": "593781",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.8800001,
+   "isDrc": true,
+   "trackAbsoluteLoudnessLkfs": -15.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 132104,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "1275"
+   },
+   "lastModified": "1785014351504359",
+   "contentLength": "8177245",
+   "quality": "tiny",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 110171,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "593781",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": 1.1099997,
+   "trackAbsoluteLoudnessLkfs": -12.89,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  },
+  {
+   "itag": 251,
+   "url": "https://redacted.googlevideo.com/videoplayback?itag=251&c=VISIONOS",
+   "mimeType": "audio/webm; codecs=\"opus\"",
+   "bitrate": 132262,
+   "initRange": {
+    "start": "0",
+    "end": "258"
+   },
+   "indexRange": {
+    "start": "259",
+    "end": "1275"
+   },
+   "lastModified": "1785014393903968",
+   "contentLength": "8205418",
+   "quality": "tiny",
+   "xtags": "CggKA2RyYxIBMQ",
+   "projectionType": "RECTANGULAR",
+   "averageBitrate": 110551,
+   "audioQuality": "AUDIO_QUALITY_MEDIUM",
+   "approxDurationMs": "593781",
+   "audioSampleRate": "48000",
+   "audioChannels": 2,
+   "loudnessDb": -1.8800001,
+   "isDrc": true,
+   "trackAbsoluteLoudnessLkfs": -15.88,
+   "qualityOrdinal": "QUALITY_ORDINAL_UNKNOWN"
+  }
+ ],
+ "hlsManifestUrl": "https://redacted.youtube.com/manifest.m3u8",
+ "aspectRatio": 1.7777778,
+ "serverAbrStreamingUrl": "https://redacted.googlevideo.com/videoplayback?redacted=1"
+}

--- a/src-tauri/tests/innertube_clients.rs
+++ b/src-tauri/tests/innertube_clients.rs
@@ -1,0 +1,159 @@
+//! Guards on the InnerTube client registry.
+//!
+//! These lock the two properties that broke playback before the registry existed:
+//! a PO token being sent to a client whose attestation platform cannot validate it
+//! (googlevideo refuses the claim, which is worse than sending nothing), and a
+//! client's identity disagreeing with itself between the request and the media
+//! fetch that follows it.
+
+use flow_desktop_lib::api::innertube::core::clients::{
+    self, ANDROID, ANDROID_CREATOR, ANDROID_VR, ANDROID_VR_1_43_32, ANDROID_VR_NO_AUTH,
+    AttestationPlatform, IOS, IPADOS, TVHTML5_SIMPLY_EMBEDDED_PLAYER, VISIONOS, WEB, WEB_REMIX,
+};
+use flow_desktop_lib::api::innertube::music::clients::DIRECT_AUDIO_CLIENTS;
+
+#[test]
+fn non_web_clients_never_carry_a_botguard_token() {
+    for client in [VISIONOS, IOS, IPADOS, ANDROID, ANDROID_VR, ANDROID_CREATOR] {
+        let context = client.player_context(Some("visitor"), Some("a-botguard-token"), None);
+        assert!(
+            context.get("serviceIntegrityDimensions").is_none(),
+            "{} is attested by {:?}, so a BotGuard token must not be attached",
+            client.name,
+            client.attestation
+        );
+        assert!(!client.accepts_web_po_token(), "{}", client.name);
+    }
+}
+
+#[test]
+fn web_family_does_carry_a_botguard_token() {
+    let context = WEB.player_context(Some("visitor"), Some("a-botguard-token"), None);
+    assert_eq!(
+        context["serviceIntegrityDimensions"]["poToken"], "a-botguard-token",
+        "WEB is the one family Flow can attest, so it must send the token"
+    );
+    assert_eq!(WEB.attestation, AttestationPlatform::Web);
+}
+
+#[test]
+fn an_empty_token_is_never_attached() {
+    let context = WEB.player_context(Some("visitor"), Some(""), None);
+    assert!(context.get("serviceIntegrityDimensions").is_none());
+}
+
+#[test]
+fn every_client_user_agent_embeds_its_own_version() {
+    // The drift this registry replaced: ANDROID was requested as 21.03.38 while
+    // its media bytes were fetched with a 19.29.37 User-Agent. Mobile clients name
+    // their version in the UA, so the two can be checked against each other.
+    for client in [
+        ANDROID,
+        ANDROID_CREATOR,
+        ANDROID_VR,
+        ANDROID_VR_1_43_32,
+        ANDROID_VR_NO_AUTH,
+        IOS,
+        IPADOS,
+    ] {
+        assert!(
+            client.user_agent.contains(client.version),
+            "{} v{} has a User-Agent that names a different build: {}",
+            client.name,
+            client.version,
+            client.user_agent
+        );
+    }
+}
+
+#[test]
+fn client_version_is_never_the_client_id() {
+    for client in [WEB, WEB_REMIX, ANDROID, VISIONOS, IOS] {
+        assert_ne!(
+            client.version, client.client_id,
+            "{} is sending its client id in the version field",
+            client.name
+        );
+    }
+    assert_eq!(WEB_REMIX.client_id, "67");
+    assert!(WEB_REMIX.version.starts_with("1.2026"));
+}
+
+#[test]
+fn lookup_resolves_the_names_media_urls_carry() {
+    // The media proxy resolves a fetch User-Agent from a googlevideo URL's `c=`
+    // parameter through this lookup, so every client that can mint one must
+    // resolve — case-insensitively, because `c=` casing is not guaranteed.
+    for client in [VISIONOS, ANDROID, ANDROID_VR, IOS, WEB, WEB_REMIX] {
+        let found = clients::by_name(client.name).expect(client.name);
+        assert_eq!(found.client_id, client.client_id);
+        let lowercased = clients::by_name(&client.name.to_lowercase()).expect(client.name);
+        assert_eq!(lowercased.client_id, client.client_id);
+    }
+    assert!(clients::by_name("NOT_A_CLIENT").is_none());
+}
+
+#[test]
+fn client_ids_parse_for_the_sabr_streamer_context() {
+    assert_eq!(VISIONOS.client_name_id(), 101);
+    assert_eq!(WEB.client_name_id(), 1);
+    assert_eq!(ANDROID_VR.client_name_id(), 28);
+    assert_eq!(IOS.client_name_id(), 5);
+}
+
+#[test]
+fn signature_timestamp_is_sent_only_where_the_client_asks_for_it() {
+    assert!(
+        VISIONOS.signature_timestamp().is_none(),
+        "VISIONOS serves un-signed URLs; sending a timestamp is a fingerprint mismatch"
+    );
+    assert!(ANDROID_VR.signature_timestamp().is_none());
+    assert_eq!(
+        IOS.signature_timestamp(),
+        Some(clients::DEFAULT_SIGNATURE_TIMESTAMP)
+    );
+}
+
+#[test]
+fn direct_audio_chain_leads_with_the_token_free_client() {
+    assert_eq!(
+        DIRECT_AUDIO_CLIENTS.first().map(|client| client.name),
+        Some(VISIONOS.name),
+        "VISIONOS is the only direct client served past the first minute unattested"
+    );
+}
+
+#[test]
+fn direct_audio_chain_excludes_the_sabr_only_iphone_clients() {
+    // IOS and IPADOS return SABR-only responses with no direct URLs, so every
+    // attempt was a wasted round trip — and they were the two clients being handed
+    // a BotGuard token that iOSGuard cannot validate.
+    assert!(
+        !DIRECT_AUDIO_CLIENTS
+            .iter()
+            .any(|client| client.name == "IOS"),
+        "IOS/IPADOS serve no direct audio URLs and must not be in the audio chain"
+    );
+}
+
+#[test]
+fn direct_audio_chain_ends_with_the_age_gate_bypass() {
+    assert_eq!(
+        DIRECT_AUDIO_CLIENTS.last().map(|client| client.name),
+        Some(TVHTML5_SIMPLY_EMBEDDED_PLAYER.name),
+        "the embedded player is the last resort, not a default"
+    );
+}
+
+#[test]
+fn context_carries_visitor_data_and_region_when_given() {
+    let context = ANDROID.context(Some("visitor-token"), Some("DE"));
+    assert_eq!(context["client"]["visitorData"], "visitor-token");
+    assert_eq!(context["client"]["gl"], "DE");
+    assert_eq!(context["client"]["clientName"], "ANDROID");
+    assert_eq!(context["client"]["androidSdkVersion"], "34");
+
+    let default_region = ANDROID.context(None, None);
+    assert_eq!(default_region["client"]["gl"], "US");
+    assert!(default_region["client"].get("visitorData").is_none());
+}

--- a/src-tauri/tests/sync_apply.rs
+++ b/src-tauri/tests/sync_apply.rs
@@ -571,3 +571,60 @@ async fn apply_music_brain_merges_into_effective() {
     let blocked: Vec<String> = serde_json::from_value(brain["blocked_artists"].clone()).unwrap();
     assert!(blocked.contains(&"UCspam".to_string()) && blocked.contains(&"UCbad".to_string()));
 }
+
+#[tokio::test]
+async fn an_android_shaped_brain_record_applies_instead_of_rolling_back_everything() {
+    // Regression for issue #46. Flow for Android sends the brain with its counters, sets, LWW-maps
+    // and flags at the top level and its G-Counters wrapped in `perDevice`. The strict decoder
+    // failed with `invalid type: map, expected u64`, and because apply is one transaction that
+    // rollback took *every* collection with it — the phone reported success while the desktop
+    // imported nothing. The record below is shaped exactly as `BrainMapper.toCanonical` emits it.
+    let pool = memory_pool().await;
+    seed_setting(
+        &pool,
+        "user_neuro_brain",
+        r#"{"idf_total_documents":100,"total_interactions":50,"blocked_topics":["politics"]}"#,
+    )
+    .await;
+
+    let android_record = format!(
+        r#"{{"schema":13,"deviceId":"{PEER}","hlc":"1000:0:{PEER}",
+            "vectors":{{"globalVector":{{"topics":{{"coding":0.5}},"duration":0.5,"pacing":0.4,"complexity":0.6,"isLive":0.0}},
+                        "timeVectors":{{"WEEKDAY_EVENING":{{"topics":{{"music":0.9}},"duration":0.5,"pacing":0.5,"complexity":0.5,"isLive":0.0}}}}}},
+            "idfTotalDocuments":{{"perDevice":{{"{PEER}":200}}}},
+            "totalInteractions":{{"perDevice":{{"{PEER}":25}}}},
+            "idfWordFrequency":{{"music":{{"perDevice":{{"{PEER}":3}}}}}},
+            "watchHistoryMap":{{"vid1":0.75}},
+            "suppressedVideoIds":{{"vidbad":1784462799000}},
+            "blockedTopics":["gaming"],
+            "hasCompletedOnboarding":true}}"#
+    );
+
+    let payload = StagedCollection {
+        collection: Collection::FlowNeuroBrain,
+        ndjson: android_record.replace(['\n', ' '], "").into_bytes(),
+        record_count: 1,
+        hash: "android-brain-1".to_string(),
+    };
+    apply_payload(&pool, OUR, PEER, &[payload]).await.unwrap();
+
+    let brain: serde_json::Value =
+        serde_json::from_str(&read_setting(&pool, "user_neuro_brain").await).unwrap();
+    // The `perDevice` wrapper is unwrapped and the counter merges without double-counting.
+    assert_eq!(brain["idf_total_documents"], 300); // local 100 + phone 200
+    assert_eq!(brain["total_interactions"], 75); // local 50 + phone 25
+    // Top-level sets/maps/flags reach their grouped homes instead of being silently dropped.
+    let blocked: Vec<String> = serde_json::from_value(brain["blocked_topics"].clone()).unwrap();
+    assert!(blocked.contains(&"politics".to_string()) && blocked.contains(&"gaming".to_string()));
+    assert_eq!(brain["watch_history_map"]["vid1"], 0.75);
+    assert!(brain["suppressed_video_ids"].get("vidbad").is_some());
+    assert_eq!(brain["has_completed_onboarding"], true);
+    assert!(brain["global_vector"]["topics"].get("coding").is_some());
+    // Android's SCREAMING_SNAKE bucket key maps onto our own spelling.
+    assert!(
+        brain["time_vectors"]["WeekdayEvening"]["topics"]
+            .get("music")
+            .is_some(),
+        "the phone's time-of-day vector must survive the bucket-name difference"
+    );
+}

--- a/src-tauri/tests/sync_compat.rs
+++ b/src-tauri/tests/sync_compat.rs
@@ -1,0 +1,324 @@
+//! Cross-platform tolerance tests for the sync wire model.
+//!
+//! These lock the two things that made phone→desktop sync fail in the field: the FlowNeuro brain
+//! envelope Flow for Android actually sends (issue #46) and the LAN address the QR advertises when
+//! a VPN or container bridge is present (issue #41). The Android payloads below are shaped exactly
+//! as `sync/canonical/Canonical.kt` + `sync/mapping/BrainMapper.kt` serialize them.
+//!
+//! They live in an integration test for the same reason as `sync_crdt.rs`: the in-crate unit-test
+//! harness fails to launch on Windows against Tauri's cdylib.
+
+use std::net::IpAddr;
+
+use flow_desktop_lib::sync::canonical::{FlowNeuroBrainSnapshot, GCounter, Hlc, Lww, OrSet};
+use flow_desktop_lib::sync::merge::merge_flow_neuro;
+use flow_desktop_lib::sync::transport::rank_lan_candidates;
+
+const ANDROID_DEVICE: &str = "d68ec770-8084-4f42-9914-132eca886f13";
+const ANDROID_HLC: &str = "1784462799000:0:d68ec770";
+
+/// One `flow_neuro_brain` NDJSON record exactly as Flow for Android v2.2.0 emits it: counters,
+/// per-video maps, sets, LWW-maps and flags all at the top level, G-Counters wrapped in
+/// `perDevice`, vector dimensions inline, and no stamps on the sets/registers.
+fn android_brain_record() -> String {
+    format!(
+        r#"{{
+          "schema": 13,
+          "deviceId": "{ANDROID_DEVICE}",
+          "hlc": "{ANDROID_HLC}",
+          "vectors": {{
+            "globalVector": {{"topics":{{"music":0.8}},"duration":0.5,"pacing":0.4,"complexity":0.6,"isLive":0.0}},
+            "timeVectors": {{"WEEKDAY_EVENING":{{"topics":{{"music":0.9}},"duration":0.5,"pacing":0.5,"complexity":0.5,"isLive":0.0}}}},
+            "shortsVector": {{"topics":{{}},"duration":0.5,"pacing":0.5,"complexity":0.5,"isLive":0.0}},
+            "topicAffinities": {{"music":0.7}},
+            "channelScores": {{"UC123":0.6}},
+            "channelTopicProfiles": {{"UC123":{{"music":0.9}}}}
+          }},
+          "idfTotalDocuments": {{"perDevice":{{"{ANDROID_DEVICE}":42}}}},
+          "totalInteractions": {{"perDevice":{{"{ANDROID_DEVICE}":17}}}},
+          "idfWordFrequency": {{"music":{{"perDevice":{{"{ANDROID_DEVICE}":3}}}}}},
+          "watchHistoryMap": {{"vid1":0.75}},
+          "seenShortsHistory": {{"short1":1784462799000}},
+          "suppressedVideoIds": {{"vidbad":1784462799000}},
+          "suppressedChannels": {{"UCbad":1784462799000}},
+          "rejectionPatterns": {{"clickbait":{{"count":2,"lastRejectedAt":1784462799000}}}},
+          "feedHistory": {{"vid1":{{"lastShown":1784462799000,"showCount":3}}}},
+          "topicEvidence": {{"music":{{"positiveSignals":4,"watchSignals":3,"explicitSignals":1,"positiveScore":0.8,"videoIds":["vid1"],"channelIds":["UC123"],"firstSeenAt":1,"lastSeenAt":2}}}},
+          "blockedTopics": ["politics"],
+          "blockedChannels": ["UCblocked"],
+          "preferredTopics": ["music"],
+          "hasCompletedOnboarding": true
+        }}"#
+    )
+}
+
+// ---- G-Counter -------------------------------------------------------------------------------
+
+#[test]
+fn gcounter_accepts_both_the_canonical_map_and_androids_per_device_wrapper() {
+    let canonical: GCounter = serde_json::from_str(r#"{"dev-a":12,"dev-b":30}"#).unwrap();
+    let wrapped: GCounter =
+        serde_json::from_str(r#"{"perDevice":{"dev-a":12,"dev-b":30}}"#).unwrap();
+    assert_eq!(canonical, wrapped);
+    assert_eq!(canonical.total(), 42);
+    assert_eq!(canonical.get("dev-a"), 12);
+}
+
+#[test]
+fn gcounter_still_serializes_as_the_bare_map() {
+    let counter = GCounter::single("dev-a", 7);
+    assert_eq!(serde_json::to_string(&counter).unwrap(), r#"{"dev-a":7}"#);
+}
+
+// ---- OR-Set / LWW ------------------------------------------------------------------------------
+
+#[test]
+fn orset_accepts_a_bare_member_array() {
+    let from_array: OrSet = serde_json::from_str(r#"["music","tech"]"#).unwrap();
+    assert!(from_array.contains("music"));
+    assert!(from_array.contains("tech"));
+    assert!(!from_array.contains("politics"));
+    assert!(from_array.removes.is_empty());
+
+    // The canonical stamped form is unchanged.
+    let stamped: OrSet =
+        serde_json::from_str(r#"{"adds":{"music":"5:0:aaaa"},"removes":{"music":"9:0:bbbb"}}"#)
+            .unwrap();
+    assert!(!stamped.contains("music"), "a later remove must win");
+}
+
+#[test]
+fn lww_accepts_a_bare_value_and_the_stamped_register() {
+    let bare: Lww<u64> = serde_json::from_str("1784462799000").unwrap();
+    assert_eq!(bare.value, 1_784_462_799_000);
+    assert_eq!(bare.hlc, Hlc::default());
+
+    let stamped: Lww<u64> =
+        serde_json::from_str(r#"{"value":1784462799000,"hlc":"5:0:aaaa"}"#).unwrap();
+    assert_eq!(stamped.value, 1_784_462_799_000);
+    assert_eq!(stamped.hlc, Hlc::new(5, 0, "aaaa"));
+}
+
+// ---- The brain snapshot ------------------------------------------------------------------------
+
+#[test]
+fn androids_flat_brain_envelope_parses_instead_of_aborting_the_apply() {
+    // Before the compat layer this failed with `invalid type: map, expected u64`, which rolled back
+    // the whole apply transaction — so nothing synced at all whenever the brain was selected.
+    let snapshot: FlowNeuroBrainSnapshot =
+        serde_json::from_str(&android_brain_record()).expect("android brain record must parse");
+
+    assert_eq!(snapshot.schema, 13);
+    assert_eq!(snapshot.device_id, ANDROID_DEVICE);
+    assert_eq!(snapshot.hlc, Hlc::new(1_784_462_799_000, 0, "d68ec770"));
+}
+
+#[test]
+fn androids_top_level_fields_land_in_their_grouped_homes() {
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(&android_brain_record()).unwrap();
+
+    // counters / idf words
+    assert_eq!(
+        snapshot.counters.idf_total_documents.get(ANDROID_DEVICE),
+        42
+    );
+    assert_eq!(snapshot.counters.total_interactions.total(), 17);
+    assert_eq!(snapshot.idf_word_frequency["music"].total(), 3);
+
+    // perVideo
+    assert_eq!(snapshot.per_video.watch_history_map["vid1"], 0.75);
+
+    // sets
+    assert!(snapshot.sets.blocked_topics.contains("politics"));
+    assert!(snapshot.sets.blocked_channels.contains("UCblocked"));
+    assert!(snapshot.sets.preferred_topics.contains("music"));
+
+    // lwwMaps
+    assert_eq!(
+        snapshot.lww_maps.suppressed_video_ids["vidbad"].value,
+        1_784_462_799_000
+    );
+    assert_eq!(
+        snapshot.lww_maps.suppressed_channels["UCbad"].value,
+        1_784_462_799_000
+    );
+    assert_eq!(
+        snapshot.lww_maps.rejection_patterns["clickbait"]
+            .value
+            .count,
+        2
+    );
+    assert_eq!(snapshot.lww_maps.feed_history["vid1"].value.show_count, 3);
+    let evidence = &snapshot.lww_maps.topic_evidence["music"].value;
+    assert_eq!(evidence.positive_signals, 4);
+    assert_eq!(evidence.watch_signals, 3);
+    assert!(evidence.video_ids.contains("vid1"));
+
+    // flags
+    assert!(snapshot.flags.has_completed_onboarding);
+}
+
+#[test]
+fn androids_inline_vector_dimensions_are_folded_into_dims() {
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(&android_brain_record()).unwrap();
+
+    let global = &snapshot.vectors.global_vector;
+    assert_eq!(global.topics["music"], 0.8);
+    assert_eq!(global.dims["duration"], 0.5);
+    assert_eq!(global.dims["pacing"], 0.4);
+    assert_eq!(global.dims["complexity"], 0.6);
+    assert_eq!(global.dims["isLive"], 0.0);
+    assert!(snapshot.vectors.shorts_vector.is_some());
+}
+
+#[test]
+fn androids_screaming_snake_bucket_keys_are_rewritten_on_ingest() {
+    // Android keys its time vectors by the Kotlin enum name. Rewriting must happen here, at the
+    // decode boundary — left alone, `WEEKDAY_EVENING` and our `WeekdayEvening` survive as two
+    // distinct keys through the whole CRDT merge and never blend.
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(&android_brain_record()).unwrap();
+
+    assert_eq!(
+        snapshot.vectors.time_vectors["WeekdayEvening"].topics["music"],
+        0.9
+    );
+    assert!(
+        !snapshot
+            .vectors
+            .time_vectors
+            .contains_key("WEEKDAY_EVENING")
+    );
+}
+
+#[test]
+fn an_already_canonical_bucket_key_wins_a_collision() {
+    let raw = r#"{"vectors":{"timeVectors":{
+        "WEEKDAY_EVENING":{"topics":{"music":0.9}},
+        "WeekdayEvening":{"topics":{"coding":0.3}}
+    }}}"#;
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(raw).unwrap();
+
+    assert_eq!(snapshot.vectors.time_vectors.len(), 1);
+    assert_eq!(
+        snapshot.vectors.time_vectors["WeekdayEvening"].topics["coding"],
+        0.3
+    );
+}
+
+#[test]
+fn an_unrecognized_bucket_key_is_passed_through_rather_than_dropped() {
+    let raw = r#"{"vectors":{"timeVectors":{"SomeFutureBucket":{"topics":{"music":0.9}}}}}"#;
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(raw).unwrap();
+
+    assert_eq!(
+        snapshot.vectors.time_vectors["SomeFutureBucket"].topics["music"],
+        0.9
+    );
+}
+
+#[test]
+fn unstamped_sets_and_registers_inherit_the_snapshot_hlc() {
+    // Left at the zero stamp they would lose every merge against a local write, and an old remove
+    // tombstone would silently un-block a channel the user just blocked on the phone.
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(&android_brain_record()).unwrap();
+    let expected = Hlc::new(1_784_462_799_000, 0, "d68ec770");
+
+    assert_eq!(snapshot.sets.blocked_topics.adds["politics"], expected);
+    assert_eq!(snapshot.sets.blocked_channels.adds["UCblocked"], expected);
+    assert_eq!(
+        snapshot.lww_maps.suppressed_video_ids["vidbad"].hlc,
+        expected
+    );
+    assert_eq!(snapshot.lww_maps.feed_history["vid1"].hlc, expected);
+    assert_eq!(snapshot.lww_maps.topic_evidence["music"].hlc, expected);
+}
+
+#[test]
+fn an_android_snapshot_carries_its_experience_weight_into_the_merge() {
+    // The blend weights each device by its idf document count; if the counter had stayed at the
+    // top level it would read as 0 and the phone's learned vectors would count for nothing.
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(&android_brain_record()).unwrap();
+    let merged = merge_flow_neuro(&[snapshot]);
+
+    let device = &merged.device_vectors[ANDROID_DEVICE];
+    assert_eq!(device.weight, 42);
+    assert_eq!(merged.counters.total_interactions.total(), 17);
+    assert!(merged.sets.blocked_topics.contains("politics"));
+}
+
+#[test]
+fn the_canonical_grouped_envelope_still_round_trips_byte_for_byte() {
+    // Desktop→desktop sync and the persisted merged-brain blob both depend on this.
+    let snapshot: FlowNeuroBrainSnapshot = serde_json::from_str(&android_brain_record()).unwrap();
+    let canonical = serde_json::to_string(&snapshot).unwrap();
+    let reparsed: FlowNeuroBrainSnapshot = serde_json::from_str(&canonical).unwrap();
+
+    assert_eq!(snapshot, reparsed);
+    assert_eq!(canonical, serde_json::to_string(&reparsed).unwrap());
+    // And the emitted form is the grouped one, not what we accepted.
+    assert!(canonical.contains(r#""counters":{"idfTotalDocuments":{""#));
+    assert!(canonical.contains(r#""lwwMaps":"#));
+    assert!(!canonical.contains("perDevice"));
+}
+
+// ---- LAN address selection ---------------------------------------------------------------------
+
+fn iface(name: &str, ip: &str) -> (String, IpAddr) {
+    (name.to_string(), ip.parse().unwrap())
+}
+
+#[test]
+fn a_vpn_tunnel_address_never_wins_over_the_real_lan() {
+    // Issue #41: with Mullvad up the QR advertised the tunnel address, which exists only inside the
+    // tunnel — the phone dialled it and nothing ever reached the desktop.
+    let candidates = rank_lan_candidates(vec![
+        iface("lo", "127.0.0.1"),
+        iface("wg0-mullvad", "10.64.0.2"),
+        iface("wlan0", "192.168.1.113"),
+    ]);
+    assert_eq!(candidates[0].ip, "192.168.1.113");
+    assert_eq!(candidates[0].interface, "wlan0");
+    assert!(!candidates[0].virtual_iface);
+    // The tunnel is still offered as a fallback, just last.
+    assert_eq!(candidates.len(), 2);
+    assert!(candidates[1].virtual_iface);
+}
+
+#[test]
+fn a_physical_ten_dot_lan_beats_a_virtual_adapter_in_a_preferred_range() {
+    let candidates = rank_lan_candidates(vec![
+        iface("vboxnet0", "192.168.56.1"),
+        iface("eth0", "10.220.141.9"),
+    ]);
+    assert_eq!(candidates[0].ip, "10.220.141.9");
+}
+
+#[test]
+fn container_bridges_and_overlay_ranges_rank_below_a_real_lan() {
+    let candidates = rank_lan_candidates(vec![
+        iface("tailscale0", "100.101.102.103"),
+        iface("docker0", "172.17.0.1"),
+        iface("enp3s0", "172.16.4.20"),
+    ]);
+    // 172.16/12 is a legitimate private LAN — the old code skipped the whole range outright.
+    assert_eq!(candidates[0].ip, "172.16.4.20");
+}
+
+#[test]
+fn unusable_addresses_are_dropped_entirely() {
+    let candidates = rank_lan_candidates(vec![
+        iface("lo", "127.0.0.1"),
+        iface("eth0", "169.254.31.7"),
+        iface("eth1", "0.0.0.0"),
+    ]);
+    assert!(candidates.is_empty());
+}
+
+#[test]
+fn a_host_with_only_a_tunnel_still_gets_an_address() {
+    // Better to advertise something the user can sanity-check against the log than to refuse.
+    let candidates = rank_lan_candidates(vec![iface("tun0", "10.64.0.2")]);
+    assert_eq!(candidates.len(), 1);
+    assert_eq!(candidates[0].ip, "10.64.0.2");
+    assert!(candidates[0].virtual_iface);
+}

--- a/src-tauri/tests/sync_fuzz.rs
+++ b/src-tauri/tests/sync_fuzz.rs
@@ -102,17 +102,23 @@ fn random_bytes_never_panic_the_decoder() {
 
 #[test]
 fn decode_chunk_handles_edge_shapes() {
-    // No newline at all → error, no panic.
+    // Not a newline in sight and not JSON either → error, no panic.
     assert!(decode_chunk(b"no-newline-here").is_err());
-    // Valid header then empty ndjson (newline is the last byte).
     let header = ChunkHeader {
         collection: None,
         seq: 0,
         last: true,
     };
-    let mut body = serde_json::to_vec(&header).unwrap();
+    let header_json = serde_json::to_vec(&header).unwrap();
+    // Valid header then empty ndjson (newline is the last byte).
+    let mut body = header_json.clone();
     body.push(b'\n');
     let (h, nd) = decode_chunk(&body).unwrap();
+    assert!(h.last);
+    assert!(nd.is_empty());
+    // Header with no separator at all: Flow for Android ≤ 2.2.0 frames a zero-record collection
+    // this way, so it must decode as an empty chunk rather than fail the session (issues #30/#49).
+    let (h, nd) = decode_chunk(&header_json).unwrap();
     assert!(h.last);
     assert!(nd.is_empty());
     // Garbage header JSON before the newline → error.

--- a/src/lib/i18n/strings.json
+++ b/src/lib/i18n/strings.json
@@ -1147,6 +1147,8 @@
   "sync_expires_in": "Expires in %ss",
   "sync_expired": "Code expired",
   "sync_preparing": "Preparing…",
+  "sync_host_address": "This PC: %s",
+  "sync_host_address_hint": "The other device must be able to reach this address. If it can't connect, check that both devices are on the same network and that a VPN or firewall isn't blocking it.",
   "sync_cancel": "Cancel",
 
   "sync_camera_error": "Could not start the camera. Paste the code manually instead, or check camera permissions.",

--- a/src/pages/Sync.tsx
+++ b/src/pages/Sync.tsx
@@ -380,6 +380,11 @@ function PairingState() {
       </div>
       {!expired && <p className="mt-2 font-mono text-xs text-chrome-neutral-500">{getString("sync_expires_in", remaining)}</p>}
 
+      <p className="mt-6 font-mono text-xs text-chrome-neutral-500">
+        {getString("sync_host_address", `${hostInfo.ip}:${hostInfo.port}`)}
+      </p>
+      <p className="mt-1 max-w-xs text-xs text-chrome-neutral-600">{getString("sync_host_address_hint")}</p>
+
       <button
         type="button"
         onClick={() => void cancel()}


### PR DESCRIPTION
## Summary

Consolidates every InnerTube client identity into a single registry and restores dubbed
audio track selection.

**Clients.** The same client used to be declared in five places and the copies had drifted:
`ANDROID` was requested as `21.03.38` but its media bytes were fetched with a `19.29.37`
User-Agent (a known googlevideo 403 cause), `WEB_REMIX` was sent with its client *id* (`67`)
in the version field, and the SABR profile reported a `WEB` version two years older than the
extractor's. All of them now come from `src-tauri/src/api/innertube/core/clients.rs`, which
`post_innertube`, `post_music`, the SABR `ClientProfile`, and the media proxy's UA resolution
read from.

**Attestation gate.** Each client declares an `AttestationPlatform` (Web / DroidGuard /
IosGuard). Flow can only mint BotGuard (web-family) tokens; attaching one to an `IOS`,
`ANDROID_VR`, or `VISIONOS` request is a claim googlevideo validates and *refuses* — strictly
worse than sending nothing. The IOS video fallback and the music chain's IPADOS/IOS clients
were doing exactly that. `player_context()` now enforces the gate centrally.

**Primary client is VISIONOS.** YouTube began requiring a GVS PO token for `ANDROID_VR`.
VISIONOS (id 101, v1.02, `RealityDevice17,1`) serves direct URLs with no PO token and no `n`
param, which matters because desktop has no JS cipher solver. ANDROID_VR stays below it as a
degraded fallback. IOS/IPADOS were dropped from the music chain — they return SABR-only
responses with no direct URLs, so every attempt was a wasted round trip.

**Silent-playback fix.** VISIONOS returns every audio itag twice — a plain copy and an
`xtags` twin — with bitrates differing by single digits (itag 139: 50223 vs 50228). Both
carry identical identity fields, so they collided on one dedup key, and the old
"keep the higher bitrate" rule let the twin win and take the `audioIsDefault` flag with it.
`build_synthetic_dash_manifest` selects on that flag, so it emitted no manifest and playback
fell back to the progressive URL — which is video-only, because VISIONOS serves no muxed
format at all. Symptom was "video plays, no audio" on almost every video. Candidates are now
ranked `(!has_xtags, declared_default, !is_auto_dubbed, bitrate)`, `is_default` is never
derived positionally, and a default is promoted after dedup if the response declared none.

**Dubbed audio.** Dubs were removed in June because googlevideo 403'd the URLs — that turned
out to be iPadOS-specific. VISIONOS dub URLs serve full sustained reads (verified: 206 on
`bytes=0-4194303` and on open-ended reads across `ar`, `es-US`, `de-DE`). The backend now
offers one track per language via `select_playable_audio_tracks`, all in a single container
chosen from whatever the original track would have picked on its own — so playback for anyone
who never opens the menu is byte-identical to before. `build_synthetic_dash_manifest` emits
one AdaptationSet per language with `Role=main` on the original and `alternate` on the rest.

No frontend changes were required: the track menu and `applyDashAudioSelection` (dash.js
`setCurrentTrack`, matching by id → lang → label) were already in place and were only ever
empty because the backend narrowed the list to one entry.

**Incidental fix.** `<BaseURL>` in the synthetic manifest was not XML-escaped. Latent today
since proxy URLs carry no query string, but a single `&` would have made the whole manifest
unparseable.

## Related issue

<!-- Use "Closes #123" when this PR should close an issue. -->

## Change type

- [x] Bug fix
- [x] Feature
- [x] Refactor or maintenance
- [ ] Documentation
- [ ] Build, packaging, or CI

## Validation

Windows 11 (x86_64), `pnpm tauri dev`.

- [ ] `pnpm test` — not run; no frontend code changed in this PR
- [x] `pnpm build` — ran `pnpm exec tsc --noEmit`, exit 0
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` — clean
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features` — no new warnings
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --all-targets --all-features` — 142 passed, 0 failed (up from 133)
- [x] I smoke-tested the affected desktop behavior.

28 new tests:
- `src-tauri/tests/innertube_clients.rs` — attestation gating, UA/version agreement,
  version-is-not-client-id, `by_name` lookup, signature-timestamp gating, music chain order.
- `src-tauri/tests/audio_tracks.rs` — the xtags-twin regression and the dubbed-language
  selection, five of them driven by real captured VISIONOS responses in `tests/fixtures/`.
- `src-tauri/tests/dash_manifest.rs` — every language becomes an AdaptationSet, exactly one
  `Role=main` and it precedes the alternates, unique ids, no `lang="und"`.

Manual: audio playback confirmed working across several videos after the default-flag fix.
Dub switching is verified at the manifest level (real generated XML inspected, 20 languages)
but **not yet exercised in the running app** — dash.js behavior with 20 audio AdaptationSets
is outside what a Rust test can reach.

## Risk and compatibility

- Backend-only. No migrations, no schema changes, no new Tauri permissions, no new dependencies.
- **Behavioral risk is concentrated in the client swap.** If YouTube changes what VISIONOS is
  served, playback degrades to the ANDROID_VR → ANDROID → IOS ladder rather than failing
  outright. VISIONOS values are version-sensitive: the older `0.1`/`RealityDevice14,1` build
  answers but serves a stub ladder (17 formats, one audio track).
- `signatureTimestamp` remains pinned at `DEFAULT_SIGNATURE_TIMESTAMP = 19550`; desktop has no
  `base.js` solver to read the live value. First thing to check if signed clients start
  failing wholesale.
- Downloads are unaffected — `commands/downloads.rs` matches against the separate,
  unchanged `download_audio_tracks` list, not the narrowed playback list.
- Test fixtures are real captured responses, **sanitized**: every signed URL replaced with a
  placeholder, ciphers deleted, no `ip=` / `sparams` / `signature=` / `pot=` remaining.
- Known limitation: desktop has no `preferredAudioLanguage` setting, so dubs are
  manual-select-only (`Player.tsx` hardcodes `"original"`). Mobile auto-selects by preference.
  Left as a follow-up since it needs schema + settings UI + i18n.

- [x] No new secrets, private data, telemetry, or broad Tauri permissions were introduced.
- [ ] User-facing documentation was updated where needed.
- [x] Dependency and lockfile changes are intentional and limited to this PR. (none)
- [x] Breaking changes and upgrade steps are clearly documented. (none)
