### PR TITLE
feat(sync): sync followed channels with unsubscribe tombstones

### DIFF
--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -19,7 +19,7 @@ use crate::services::recommendation_service::RecommendationService;
 use crate::sync::apply;
 use crate::sync::canonical::{
     Collection, FlowNeuroBrainSnapshot, Like, MusicBrainSnapshot, Playlist, SettingEntry,
-    SubscriptionGroup, WatchHistoryRecord,
+    SubscribedChannel, SubscriptionGroup, WatchHistoryRecord,
 };
 use crate::sync::codec;
 use crate::sync::error::SyncError;
@@ -73,6 +73,7 @@ fn scope_collections(scope: &str) -> Option<Vec<Collection>> {
             Collection::Likes,
             Collection::Settings,
             Collection::Subscriptions,
+            Collection::SubscribedChannels,
         ]),
         "MASTER" => Some(Collection::ALL.to_vec()),
         _ => None,
@@ -117,6 +118,7 @@ fn filter_parseable(collection: Collection, values: &[Value]) -> (Vec<Value>, u6
         Collection::FlowNeuroBrain => ok::<FlowNeuroBrainSnapshot>(v, |s| !s.device_id.is_empty()),
         Collection::MusicBrain => ok::<MusicBrainSnapshot>(v, |s| !s.device_id.is_empty()),
         Collection::Subscriptions => ok::<SubscriptionGroup>(v, |g| !g.name.is_empty()),
+        Collection::SubscribedChannels => ok::<SubscribedChannel>(v, |c| !c.channel_id.is_empty()),
     };
     let kept: Vec<Value> = values.iter().filter(|v| parses(v)).cloned().collect();
     let dropped = (values.len() - kept.len()) as u64;

--- a/src-tauri/src/sync/apply.rs
+++ b/src-tauri/src/sync/apply.rs
@@ -21,7 +21,7 @@ use crate::music_brain::model::MusicBrain;
 use crate::sync::brainmap;
 use crate::sync::canonical::{
     Collection, FlowNeuroBrainSnapshot, Hlc, Like, MusicBrainSnapshot, Playlist, SettingEntry,
-    SubscriptionGroup, WatchHistoryRecord,
+    SubscribedChannel, SubscriptionGroup, WatchHistoryRecord,
 };
 use crate::sync::error::SyncError;
 use crate::sync::mapping::{self, WatchInsert, WatchRow};
@@ -109,6 +109,10 @@ pub async fn apply_payload(
             }
             Collection::Subscriptions => (
                 apply_subscriptions(&mut tx, our_device_id, &sc.ndjson).await?,
+                true,
+            ),
+            Collection::SubscribedChannels => (
+                apply_subscribed_channels(&mut tx, our_device_id, &sc.ndjson).await?,
                 true,
             ),
 
@@ -453,6 +457,58 @@ async fn apply_subscriptions(
     Ok(stat)
 }
 
+async fn apply_subscribed_channels(
+    tx: &mut Transaction<'_, Sqlite>,
+    device_id: &str,
+    ndjson: &[u8],
+) -> Result<ApplyStats, SyncError> {
+    let incoming = parse_ndjson::<SubscribedChannel>(ndjson)?;
+    let now = now_ms();
+    let node = crate::sync::canonical::short_device_id(device_id);
+
+    let existing_raw = get_setting(tx, mapping::SUBSCRIBED_CHANNELS_SETTING_KEY).await?;
+    let tombstones = match get_setting(tx, mapping::SUBSCRIPTION_TOMBSTONES_SETTING_KEY).await? {
+        Some(raw) => mapping::parse_subscription_tombstones(&raw),
+        None => BTreeMap::new(),
+    };
+    let local = mapping::parse_subscribed_channels_blob(
+        existing_raw.as_deref().unwrap_or("[]"),
+        &tombstones,
+        &node,
+    );
+    let local_map: BTreeMap<String, SubscribedChannel> = local
+        .iter()
+        .map(|c| (c.channel_id.clone(), c.clone()))
+        .collect();
+
+    let merged = merge::merge_subscribed_channels(local, incoming);
+
+    let mut stat = ApplyStats {
+        collection_key: Collection::SubscribedChannels.key().to_string(),
+        ..Default::default()
+    };
+    for channel in &merged {
+        match local_map.get(&channel.channel_id) {
+            Some(before) if before == channel => stat.skipped += 1,
+            Some(before) if channel.deleted && !before.deleted => stat.tombstoned += 1,
+            Some(_) => stat.updated += 1,
+            None if channel.deleted => stat.skipped += 1,
+            None => stat.added += 1,
+        }
+    }
+
+    let (live_blob, tombstone_blob) =
+        mapping::subscribed_channels_to_blob(&merged, existing_raw.as_deref(), now);
+    set_setting(tx, mapping::SUBSCRIBED_CHANNELS_SETTING_KEY, &live_blob).await?;
+    set_setting(
+        tx,
+        mapping::SUBSCRIPTION_TOMBSTONES_SETTING_KEY,
+        &tombstone_blob,
+    )
+    .await?;
+    Ok(stat)
+}
+
 async fn get_setting_with_time(
     tx: &mut Transaction<'_, Sqlite>,
     key: &str,
@@ -595,6 +651,16 @@ async fn backup_snapshot(
             Collection::Subscriptions => {
                 let raw = setting_value(pool, mapping::SUBSCRIPTION_GROUPS_SETTING_KEY).await?;
                 obj.insert("subscription_groups".to_string(), serde_json::json!(raw));
+            }
+            Collection::SubscribedChannels => {
+                let raw = setting_value(pool, mapping::SUBSCRIBED_CHANNELS_SETTING_KEY).await?;
+                obj.insert("subscriptions".to_string(), serde_json::json!(raw));
+                let tombs =
+                    setting_value(pool, mapping::SUBSCRIPTION_TOMBSTONES_SETTING_KEY).await?;
+                obj.insert(
+                    "subscription_tombstones".to_string(),
+                    serde_json::json!(tombs),
+                );
             }
             #[allow(unreachable_patterns)]
             _ => {}

--- a/src-tauri/src/sync/canonical.rs
+++ b/src-tauri/src/sync/canonical.rs
@@ -23,11 +23,12 @@ pub enum Collection {
     FlowNeuroBrain,
     MusicBrain,
     Subscriptions,
+    SubscribedChannels,
 }
 
 impl Collection {
     /// Every collection, in a stable order (used to iterate capabilities/selection).
-    pub const ALL: [Collection; 7] = [
+    pub const ALL: [Collection; 8] = [
         Collection::WatchHistory,
         Collection::Playlists,
         Collection::Likes,
@@ -35,6 +36,7 @@ impl Collection {
         Collection::FlowNeuroBrain,
         Collection::MusicBrain,
         Collection::Subscriptions,
+        Collection::SubscribedChannels,
     ];
 
     /// The stable wire key (matches the `snake_case` serde form), e.g. `"watch_history"`.
@@ -47,6 +49,7 @@ impl Collection {
             Collection::FlowNeuroBrain => "flow_neuro_brain",
             Collection::MusicBrain => "music_brain",
             Collection::Subscriptions => "subscriptions",
+            Collection::SubscribedChannels => "subscribed_channels",
         }
     }
 }
@@ -615,4 +618,33 @@ pub struct SubscriptionGroup {
     pub hlc: Hlc,
     pub name: String,
     pub sort_order: i32,
+}
+
+// ===========================================================================================
+// Collection: subscribed channels
+// ===========================================================================================
+
+/// One followed channel (`FLOW-SYNC/1` §10.0). Distinct from [`SubscriptionGroup`], which only
+/// carries the *folders* — a group can express neither a subscription that belongs to no group nor
+/// an unsubscribe, which is why the channels need their own collection.
+///
+/// Merged per-record LWW by `hlc` with tombstones, so subscribe-vs-unsubscribe resolves by when
+/// each actually happened. A tombstone carries no display metadata, hence the non-empty-wins rule
+/// on `name`/`avatar_url` in `merge::merge_subscribed_channels`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct SubscribedChannel {
+    /// Record key; canonical sort order is `channel_id` ascending.
+    pub channel_id: String,
+    pub name: String,
+    pub avatar_url: String,
+    /// Epoch ms the user subscribed. Merge takes the max.
+    pub subscribed_at_ms: u64,
+    /// OR-merged, never flipped off (the music↔video leak rule).
+    pub is_music: bool,
+    /// Degenerate `(subscribed_at_ms, 0, node)` for a live record, `(unsubscribed_at_ms, 0, node)`
+    /// for a tombstone.
+    pub hlc: Hlc,
+    /// `true` = unsubscribed.
+    pub deleted: bool,
 }

--- a/src-tauri/src/sync/export.rs
+++ b/src-tauri/src/sync/export.rs
@@ -48,6 +48,7 @@ pub async fn export_collections(
             Collection::FlowNeuroBrain => export_flow_neuro(pool, device_id).await?,
             Collection::MusicBrain => export_music(pool, device_id).await?,
             Collection::Subscriptions => export_subscriptions(pool, device_id).await?,
+            Collection::SubscribedChannels => export_subscribed_channels(pool, device_id).await?,
         };
         out.push(OutgoingCollection { collection, ndjson });
     }
@@ -161,6 +162,25 @@ async fn export_subscriptions(pool: &SqlitePool, device_id: &str) -> Result<Vec<
     };
     groups.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(to_ndjson(&groups))
+}
+
+/// Followed channels plus the unsubscribe tombstones we still remember (`FLOW-SYNC/1` §10.0).
+/// Record stamps come from `subscribedAt` / the tombstone time, not from now, so subscribe and
+/// unsubscribe resolve by when each actually happened.
+async fn export_subscribed_channels(
+    pool: &SqlitePool,
+    device_id: &str,
+) -> Result<Vec<u8>, SyncError> {
+    let node = crate::sync::canonical::short_device_id(device_id);
+    let tombstones = match get_setting(pool, mapping::SUBSCRIPTION_TOMBSTONES_SETTING_KEY).await? {
+        Some(raw) => mapping::parse_subscription_tombstones(&raw),
+        None => std::collections::BTreeMap::new(),
+    };
+    let channels = match get_setting(pool, mapping::SUBSCRIBED_CHANNELS_SETTING_KEY).await? {
+        Some(raw) => mapping::parse_subscribed_channels_blob(&raw, &tombstones, &node),
+        None => Vec::new(),
+    };
+    Ok(to_ndjson(&channels))
 }
 
 async fn export_settings(pool: &SqlitePool, device_id: &str) -> Result<Vec<u8>, SyncError> {

--- a/src-tauri/src/sync/mapping.rs
+++ b/src-tauri/src/sync/mapping.rs
@@ -9,14 +9,14 @@
 //! * `playlists` / `likes` — stored as frontend-authored JSON blobs in `settings`
 //!   (`user_playlists`, `liked_items`); they need lossless Rust mirrors of the TS shapes.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::sync::canonical::{
-    Hlc, Like, LikeKind, LikeState, Playlist, PlaylistItem, PlaylistOrigin, SubscriptionGroup,
-    WatchHistoryRecord,
+    Hlc, Like, LikeKind, LikeState, Playlist, PlaylistItem, PlaylistOrigin, SubscribedChannel,
+    SubscriptionGroup, WatchHistoryRecord,
 };
 
 /// Frontend settings key holding the liked-items JSON array.
@@ -25,6 +25,16 @@ pub const LIKES_SETTING_KEY: &str = "liked_items";
 pub const PLAYLISTS_SETTING_KEY: &str = "user_playlists";
 pub const ALBUMS_SETTING_KEY: &str = "saved_albums";
 pub const SUBSCRIPTION_GROUPS_SETTING_KEY: &str = "subscription_groups";
+/// Frontend settings key holding the followed-channel JSON array (the channels themselves, as
+/// opposed to the folders in [`SUBSCRIPTION_GROUPS_SETTING_KEY`]).
+pub const SUBSCRIBED_CHANNELS_SETTING_KEY: &str = "subscriptions";
+/// Unsubscribe tombstones, `{channelId: epochMs}`. Persisted rather than derived: a channel that is
+/// simply absent is indistinguishable from one this device never followed, so without this the peer
+/// would re-add everything the user just unsubscribed from (`FLOW-SYNC/1` §10.0).
+pub const SUBSCRIPTION_TOMBSTONES_SETTING_KEY: &str = "subscription_tombstones";
+/// How long an unsubscribe tombstone is retained before pruning. Matches Android so the two sides
+/// forget at the same rate.
+pub const TOMBSTONE_TTL_MS: u64 = 365 * 24 * 60 * 60 * 1000;
 /// Reserved cross-device id for the protected "Watch Later" playlist.
 pub const WATCH_LATER_SYNC_ID: &str = "reserved:watch-later";
 
@@ -69,6 +79,136 @@ pub fn parse_subscription_groups_blob(raw: &str, hlc: &Hlc) -> Vec<SubscriptionG
             }
         })
         .collect()
+}
+
+fn channel_str(entry: &Value, key: &str) -> String {
+    entry
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+/// Read the frontend's followed-channel array into canonical records, appending a tombstone for
+/// every unsubscribe we still remember. A tombstone for a channel that is live again is dropped —
+/// the live record is the newer truth.
+pub fn parse_subscribed_channels_blob(
+    raw: &str,
+    tombstones: &BTreeMap<String, u64>,
+    node: &str,
+) -> Vec<SubscribedChannel> {
+    let entries: Vec<Value> = serde_json::from_str(raw).unwrap_or_default();
+    let mut out: Vec<SubscribedChannel> = Vec::with_capacity(entries.len() + tombstones.len());
+    let mut live: BTreeSet<String> = BTreeSet::new();
+
+    for entry in &entries {
+        let channel_id = channel_str(entry, "id");
+        if channel_id.trim().is_empty() {
+            continue;
+        }
+        let subscribed_at_ms = entry
+            .get("subscribedAt")
+            .and_then(Value::as_u64)
+            .unwrap_or_default();
+        live.insert(channel_id.clone());
+        out.push(SubscribedChannel {
+            hlc: Hlc::new(subscribed_at_ms, 0, node),
+            channel_id,
+            name: channel_str(entry, "name"),
+            avatar_url: channel_str(entry, "avatarUrl"),
+            subscribed_at_ms,
+            is_music: entry
+                .get("isMusic")
+                .and_then(Value::as_bool)
+                .unwrap_or_default(),
+            deleted: false,
+        });
+    }
+
+    for (channel_id, &at) in tombstones {
+        if live.contains(channel_id) {
+            continue;
+        }
+        out.push(SubscribedChannel {
+            channel_id: channel_id.clone(),
+            hlc: Hlc::new(at, 0, node),
+            deleted: true,
+            ..SubscribedChannel::default()
+        });
+    }
+
+    out.sort_by(|a, b| a.channel_id.cmp(&b.channel_id));
+    out
+}
+
+pub fn parse_subscription_tombstones(raw: &str) -> BTreeMap<String, u64> {
+    serde_json::from_str::<BTreeMap<String, u64>>(raw).unwrap_or_default()
+}
+
+/// Project merged channels back into the frontend blob plus the tombstone map.
+///
+/// `existing_raw` is the blob being replaced: entries are patched in place rather than rebuilt, so
+/// device-local fields the wire does not carry (`subscriberCountText`, and anything the frontend
+/// adds later) survive a sync instead of being silently reset.
+pub fn subscribed_channels_to_blob(
+    merged: &[SubscribedChannel],
+    existing_raw: Option<&str>,
+    now_ms: u64,
+) -> (String, String) {
+    let existing: BTreeMap<String, Value> = existing_raw
+        .and_then(|raw| serde_json::from_str::<Vec<Value>>(raw).ok())
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|e| {
+            let id = channel_str(&e, "id");
+            (!id.is_empty()).then_some((id, e))
+        })
+        .collect();
+
+    let mut live: Vec<Value> = Vec::new();
+    let mut tombstones: BTreeMap<String, u64> = BTreeMap::new();
+
+    for channel in merged {
+        if channel.channel_id.trim().is_empty() {
+            continue;
+        }
+        if channel.deleted {
+            // Keep a tombstone even for a channel this device never had, so the unsubscribe still
+            // reaches a third device that does have it. Prune once it is older than the TTL.
+            if now_ms.saturating_sub(channel.hlc.physical_ms) <= TOMBSTONE_TTL_MS {
+                tombstones.insert(channel.channel_id.clone(), channel.hlc.physical_ms);
+            }
+            continue;
+        }
+        let mut entry = existing
+            .get(&channel.channel_id)
+            .cloned()
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+        if let Some(obj) = entry.as_object_mut() {
+            obj.insert("id".into(), Value::String(channel.channel_id.clone()));
+            if !channel.name.is_empty() {
+                obj.insert("name".into(), Value::String(channel.name.clone()));
+            }
+            if !channel.avatar_url.is_empty() {
+                obj.insert(
+                    "avatarUrl".into(),
+                    Value::String(channel.avatar_url.clone()),
+                );
+            }
+            if channel.subscribed_at_ms > 0 {
+                obj.insert("subscribedAt".into(), Value::from(channel.subscribed_at_ms));
+            }
+            if channel.is_music {
+                obj.insert("isMusic".into(), Value::Bool(true));
+            }
+        }
+        live.push(entry);
+    }
+
+    (
+        serde_json::to_string(&live).unwrap_or_else(|_| "[]".to_string()),
+        serde_json::to_string(&tombstones).unwrap_or_else(|_| "{}".to_string()),
+    )
 }
 
 pub fn subscription_groups_to_blob(groups: &[SubscriptionGroup]) -> String {

--- a/src-tauri/src/sync/merge.rs
+++ b/src-tauri/src/sync/merge.rs
@@ -29,7 +29,7 @@ use crate::sync::canonical::{
     AffinityWire, BrainCounters, BrainFlags, BrainLwwMaps, BrainPerVideo, BrainSets, BrainVectors,
     ContentVectorWire, FlowNeuroBrainSnapshot, GCounter, Hlc, Like, LikeKind, Lww,
     MusicBrainSnapshot, OrSet, Playlist, PlaylistItem, PlaylistOrigin, SettingEntry,
-    SubscriptionGroup, TrackMetaWire, WatchHistoryRecord,
+    SubscribedChannel, SubscriptionGroup, TrackMetaWire, WatchHistoryRecord,
 };
 
 // ===========================================================================================
@@ -396,19 +396,67 @@ fn merge_one_subscription(a: &SubscriptionGroup, b: &SubscriptionGroup) -> Subsc
 
     SubscriptionGroup {
         channel_ids,
-        deleted: tombstone_wins(a, b),
+        deleted: tombstone_wins(a.deleted, &a.hlc, b.deleted, &b.hlc),
         hlc: Hlc::max(&a.hlc, &b.hlc),
         name: a.name.clone(),
         sort_order,
     }
 }
 
-fn tombstone_wins(a: &SubscriptionGroup, b: &SubscriptionGroup) -> bool {
-    match (a.deleted, b.deleted) {
+/// Tombstone resolution for two records with the same key: when exactly one side is a tombstone it
+/// wins iff its stamp is `>=` the live record's. That is what makes a later delete remove the record
+/// on the peer while a later re-create restores it.
+fn tombstone_wins(a_deleted: bool, a_hlc: &Hlc, b_deleted: bool, b_hlc: &Hlc) -> bool {
+    match (a_deleted, b_deleted) {
         (true, true) => true,
         (false, false) => false,
-        (true, false) => a.hlc >= b.hlc,
-        (false, true) => b.hlc >= a.hlc,
+        (true, false) => a_hlc >= b_hlc,
+        (false, true) => b_hlc >= a_hlc,
+    }
+}
+
+// ===========================================================================================
+// Subscribed channels
+// ===========================================================================================
+
+/// Merge the followed-channel lists (`FLOW-SYNC/1` §10.0). Per-record LWW by `hlc` with tombstones.
+pub fn merge_subscribed_channels(
+    a: Vec<SubscribedChannel>,
+    b: Vec<SubscribedChannel>,
+) -> Vec<SubscribedChannel> {
+    let mut map: BTreeMap<String, SubscribedChannel> = a
+        .into_iter()
+        .filter(|c| !c.channel_id.is_empty())
+        .map(|c| (c.channel_id.clone(), c))
+        .collect();
+    for c in b.into_iter().filter(|c| !c.channel_id.is_empty()) {
+        match map.get_mut(&c.channel_id) {
+            Some(e) => *e = merge_one_channel(e, &c),
+            None => {
+                map.insert(c.channel_id.clone(), c);
+            }
+        }
+    }
+    map.into_values().collect()
+}
+
+fn merge_one_channel(a: &SubscribedChannel, b: &SubscribedChannel) -> SubscribedChannel {
+    let (win, lose) = if a_wins(a, &a.hlc, b, &b.hlc) {
+        (a, b)
+    } else {
+        (b, a)
+    };
+    let pick = |w: &String, l: &String| if w.is_empty() { l.clone() } else { w.clone() };
+    SubscribedChannel {
+        channel_id: a.channel_id.clone(),
+        // A tombstone carries no display metadata, so the winner may legitimately be blank — take
+        // the other side's value rather than blanking the channel on a re-subscribe.
+        name: pick(&win.name, &lose.name),
+        avatar_url: pick(&win.avatar_url, &lose.avatar_url),
+        subscribed_at_ms: a.subscribed_at_ms.max(b.subscribed_at_ms),
+        is_music: a.is_music || b.is_music,
+        hlc: Hlc::max(&a.hlc, &b.hlc),
+        deleted: tombstone_wins(a.deleted, &a.hlc, b.deleted, &b.hlc),
     }
 }
 

--- a/src-tauri/tests/fixtures/sync/subscribed_channels.json
+++ b/src-tauri/tests/fixtures/sync/subscribed_channels.json
@@ -1,0 +1,20 @@
+[
+  {
+    "channelId": "UCabc",
+    "name": "Some Channel",
+    "avatarUrl": "https://cdn.example/UCabc.jpg",
+    "subscribedAtMs": 1781000000000,
+    "isMusic": false,
+    "hlc": "1781000000000:0:deviceaa",
+    "deleted": false
+  },
+  {
+    "channelId": "UCgone",
+    "name": "",
+    "avatarUrl": "",
+    "subscribedAtMs": 0,
+    "isMusic": false,
+    "hlc": "1781000900000:0:deviceaa",
+    "deleted": true
+  }
+]

--- a/src-tauri/tests/sync_apply.rs
+++ b/src-tauri/tests/sync_apply.rs
@@ -8,8 +8,8 @@ use sqlx::sqlite::SqlitePoolOptions;
 use flow_desktop_lib::sync::apply::apply_payload;
 use flow_desktop_lib::sync::canonical::{
     Collection, FlowNeuroBrainSnapshot, GCounter, Hlc, Like, LikeKind, LikeState,
-    MusicBrainSnapshot, Playlist, PlaylistItem, PlaylistOrigin, SettingEntry, SubscriptionGroup,
-    WatchHistoryRecord,
+    MusicBrainSnapshot, Playlist, PlaylistItem, PlaylistOrigin, SettingEntry, SubscribedChannel,
+    SubscriptionGroup, WatchHistoryRecord,
 };
 use flow_desktop_lib::sync::mapping;
 use flow_desktop_lib::sync::protocol::StagedCollection;
@@ -627,4 +627,186 @@ async fn an_android_shaped_brain_record_applies_instead_of_rolling_back_everythi
             .is_some(),
         "the phone's time-of-day vector must survive the bucket-name difference"
     );
+}
+
+// --------------------------------------------------------------------------------------------
+// subscribed_channels (FLOW-SYNC/1 §10.0) — the channels themselves, with unsubscribe tombstones.
+// --------------------------------------------------------------------------------------------
+
+/// A realistic epoch-ms base: tombstones are pruned against wall-clock `now`, so toy stamps would
+/// read as decades old and be dropped before they could be asserted on.
+const T0: u64 = 1_781_000_000_000;
+
+fn channel(id: &str, name: &str, offset: u64, deleted: bool) -> SubscribedChannel {
+    let at = T0 + offset;
+    SubscribedChannel {
+        channel_id: id.to_string(),
+        name: name.to_string(),
+        avatar_url: if name.is_empty() {
+            String::new()
+        } else {
+            format!("https://cdn/{id}.jpg")
+        },
+        subscribed_at_ms: if deleted { 0 } else { at },
+        is_music: false,
+        hlc: Hlc::new(at, 0, PEER),
+        deleted,
+    }
+}
+
+fn channels_payload(records: &[SubscribedChannel]) -> StagedCollection {
+    StagedCollection {
+        collection: Collection::SubscribedChannels,
+        ndjson: ndjson_of(records),
+        record_count: records.len() as u64,
+        hash: format!("chan-{}", records.len()),
+    }
+}
+
+async fn seed_channels(pool: &SqlitePool, blob: &str) {
+    seed_setting(pool, "subscriptions", blob).await;
+}
+
+async fn live_ids(pool: &SqlitePool) -> Vec<String> {
+    let raw = read_setting(pool, "subscriptions").await;
+    serde_json::from_str::<Vec<serde_json::Value>>(&raw)
+        .unwrap()
+        .into_iter()
+        .filter_map(|v| v["id"].as_str().map(str::to_string))
+        .collect()
+}
+
+#[tokio::test]
+async fn a_newer_unsubscribe_from_the_peer_removes_the_local_subscription() {
+    let pool = memory_pool().await;
+    seed_channels(
+        &pool,
+        r#"[{"id":"UCx","name":"Cool","avatarUrl":"a.jpg","subscribedAt":1781000001000}]"#,
+    )
+    .await;
+
+    apply_payload(
+        &pool,
+        OUR,
+        PEER,
+        &[channels_payload(&[channel("UCx", "", 2000, true)])],
+    )
+    .await
+    .unwrap();
+
+    assert!(live_ids(&pool).await.is_empty(), "the unsubscribe must win");
+    // and it is remembered, so a third device hears about it too
+    let tombs: serde_json::Value =
+        serde_json::from_str(&read_setting(&pool, "subscription_tombstones").await).unwrap();
+    assert_eq!(tombs["UCx"], T0 + 2000);
+}
+
+#[tokio::test]
+async fn an_older_unsubscribe_does_not_remove_a_newer_subscription() {
+    let pool = memory_pool().await;
+    seed_channels(
+        &pool,
+        r#"[{"id":"UCx","name":"Cool","avatarUrl":"a.jpg","subscribedAt":1781000005000}]"#,
+    )
+    .await;
+
+    apply_payload(
+        &pool,
+        OUR,
+        PEER,
+        &[channels_payload(&[channel("UCx", "", 1000, true)])],
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(live_ids(&pool).await, vec!["UCx".to_string()]);
+}
+
+#[tokio::test]
+async fn a_peer_record_without_metadata_does_not_blank_the_channel() {
+    // A tombstone carries no display metadata, and a bare re-subscribe from a third device may not
+    // either — merging must take the non-empty side or the channel turns into a nameless row.
+    let pool = memory_pool().await;
+    seed_channels(
+        &pool,
+        r#"[{"id":"UCx","name":"Cool","avatarUrl":"a.jpg","subscribedAt":1781000001000}]"#,
+    )
+    .await;
+
+    apply_payload(
+        &pool,
+        OUR,
+        PEER,
+        &[channels_payload(&[channel("UCx", "", 9000, false)])],
+    )
+    .await
+    .unwrap();
+
+    let raw = read_setting(&pool, "subscriptions").await;
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).unwrap();
+    assert_eq!(entries[0]["name"], "Cool");
+    assert_eq!(entries[0]["avatarUrl"], "a.jpg");
+}
+
+#[tokio::test]
+async fn a_tombstone_for_a_channel_we_never_had_is_still_retained() {
+    // Otherwise the unsubscribe dies here and never reaches a third device that does follow it.
+    let pool = memory_pool().await;
+    seed_channels(&pool, "[]").await;
+
+    apply_payload(
+        &pool,
+        OUR,
+        PEER,
+        &[channels_payload(&[channel("UCghost", "", 2000, true)])],
+    )
+    .await
+    .unwrap();
+
+    let tombs: serde_json::Value =
+        serde_json::from_str(&read_setting(&pool, "subscription_tombstones").await).unwrap();
+    assert_eq!(tombs["UCghost"], T0 + 2000);
+    assert!(live_ids(&pool).await.is_empty());
+}
+
+#[tokio::test]
+async fn applying_channels_preserves_device_local_fields() {
+    // `subscriberCountText` is not on the wire. Rebuilding the entry from the canonical record
+    // instead of patching it would silently wipe it on every sync.
+    let pool = memory_pool().await;
+    seed_channels(
+        &pool,
+        r#"[{"id":"UCx","name":"Old","avatarUrl":"a.jpg","subscribedAt":1781000001000,"subscriberCountText":"1.2M subscribers"}]"#,
+    )
+    .await;
+
+    apply_payload(
+        &pool,
+        OUR,
+        PEER,
+        &[channels_payload(&[channel("UCx", "New", 4000, false)])],
+    )
+    .await
+    .unwrap();
+
+    let raw = read_setting(&pool, "subscriptions").await;
+    let entries: Vec<serde_json::Value> = serde_json::from_str(&raw).unwrap();
+    assert_eq!(entries[0]["name"], "New", "the newer name still wins");
+    assert_eq!(entries[0]["subscriberCountText"], "1.2M subscribers");
+}
+
+#[tokio::test]
+async fn re_applying_a_channel_payload_is_a_no_op() {
+    let pool = memory_pool().await;
+    seed_channels(&pool, "[]").await;
+    let payload = channels_payload(&[channel("UCx", "Cool", 3000, false)]);
+
+    apply_payload(&pool, OUR, PEER, std::slice::from_ref(&payload))
+        .await
+        .unwrap();
+    let after_first = read_setting(&pool, "subscriptions").await;
+    apply_payload(&pool, OUR, PEER, &[payload]).await.unwrap();
+
+    assert_eq!(read_setting(&pool, "subscriptions").await, after_first);
+    assert_eq!(live_ids(&pool).await, vec!["UCx".to_string()]);
 }

--- a/src-tauri/tests/sync_merge.rs
+++ b/src-tauri/tests/sync_merge.rs
@@ -10,8 +10,8 @@ use rand::{Rng, SeedableRng};
 
 use flow_desktop_lib::sync::canonical::{
     AffinityWire, FlowNeuroBrainSnapshot, GCounter, Hlc, Like, LikeKind, LikeState, Lww,
-    MusicBrainSnapshot, Playlist, PlaylistItem, PlaylistOrigin, SettingEntry, SubscriptionGroup,
-    WatchHistoryRecord,
+    MusicBrainSnapshot, Playlist, PlaylistItem, PlaylistOrigin, SettingEntry, SubscribedChannel,
+    SubscriptionGroup, WatchHistoryRecord,
 };
 use flow_desktop_lib::sync::merge;
 
@@ -203,6 +203,31 @@ fn subscriptions_merge_obeys_crdt_laws() {
         sets.push(v);
     }
     assert_laws(&sets, merge::merge_subscriptions);
+}
+
+#[test]
+fn subscribed_channels_merge_obeys_crdt_laws() {
+    let mut r = StdRng::seed_from_u64(106);
+    let mut sets: Vec<Vec<SubscribedChannel>> = Vec::new();
+    for _ in 0..6 {
+        let mut v = Vec::new();
+        for id in ["UCa", "UCb", "UCc"] {
+            if r.gen_bool(0.75) {
+                let stamp = hlc(&mut r);
+                v.push(SubscribedChannel {
+                    channel_id: id.to_string(),
+                    name: format!("name-{}", r.gen_range(0..3)),
+                    avatar_url: String::new(),
+                    subscribed_at_ms: stamp.physical_ms,
+                    is_music: r.gen_bool(0.3),
+                    hlc: stamp,
+                    deleted: r.gen_bool(0.3),
+                });
+            }
+        }
+        sets.push(v);
+    }
+    assert_laws(&sets, merge::merge_subscribed_channels);
 }
 
 // --------------------------------------------------------------------------------------------

--- a/src-tauri/tests/sync_schema.rs
+++ b/src-tauri/tests/sync_schema.rs
@@ -15,7 +15,8 @@ use serde::de::DeserializeOwned;
 
 use flow_desktop_lib::sync::canonical::{
     FlowNeuroBrainSnapshot, Like, LikeKind, LikeState, MusicBrainSnapshot, Playlist,
-    PlaylistOrigin, SettingEntry, SubscriptionGroup, WatchHistoryRecord, to_canonical_json,
+    PlaylistOrigin, SettingEntry, SubscribedChannel, SubscriptionGroup, WatchHistoryRecord,
+    to_canonical_json,
 };
 use flow_desktop_lib::sync::frames::CapabilitiesFrame;
 
@@ -139,6 +140,36 @@ fn subscriptions_fixture_locks() {
     );
     assert_eq!(groups[0].sort_order, 0);
     assert!(!groups[0].deleted);
+}
+
+#[test]
+fn subscribed_channels_fixture_locks() {
+    let channels: Vec<SubscribedChannel> = load_stable("subscribed_channels.json");
+    assert_eq!(channels.len(), 2);
+    assert_eq!(channels[0].channel_id, "UCabc");
+    assert_eq!(channels[0].subscribed_at_ms, 1_781_000_000_000);
+    assert!(!channels[0].deleted);
+    // An unsubscribe is shipped as a tombstone carrying no display metadata.
+    assert!(channels[1].deleted);
+    assert!(channels[1].name.is_empty());
+}
+
+#[test]
+fn subscribed_channel_canonical_bytes_match_android() {
+    let channel = SubscribedChannel {
+        channel_id: "UCabc".to_string(),
+        name: "Some Channel".to_string(),
+        avatar_url: "https://cdn.example/UCabc.jpg".to_string(),
+        subscribed_at_ms: 1_781_000_000_000,
+        is_music: false,
+        hlc: "1781000000000:0:deviceaa".parse().unwrap(),
+        deleted: false,
+    };
+    let json = String::from_utf8(to_canonical_json(&channel)).unwrap();
+    assert_eq!(
+        json,
+        r#"{"avatarUrl":"https://cdn.example/UCabc.jpg","channelId":"UCabc","deleted":false,"hlc":"1781000000000:0:deviceaa","isMusic":false,"name":"Some Channel","subscribedAtMs":1781000000000}"#
+    );
 }
 
 #[test]

--- a/src/lib/api/sync.ts
+++ b/src/lib/api/sync.ts
@@ -72,7 +72,8 @@ export const SYNC_COLLECTIONS: ReadonlyArray<{ key: string; label: string; descr
   { key: "settings", label: "Player & UI settings", description: "Playback, content and quality preferences" },
   { key: "flow_neuro_brain", label: "Recommendation brain", description: "Your FlowNeuro taste profile" },
   { key: "music_brain", label: "Music taste", description: "Artist affinities and listening history" },
-  { key: "subscriptions", label: "Subscription groups", description: "Your channel folders" },
+  { key: "subscribed_channels", label: "Subscriptions", description: "The channels you follow" },
+  { key: "subscriptions", label: "Subscription groups", description: "The folders you sort your channels into" },
 ];
 
 export const SYNC_STATUS_EVENT = "sync://status";

--- a/src/lib/i18n/strings.json
+++ b/src/lib/i18n/strings.json
@@ -1134,8 +1134,10 @@
   "sync_collection_flow_neuro_brain_desc": "Your FlowNeuro taste profile",
   "sync_collection_music_brain": "Music taste",
   "sync_collection_music_brain_desc": "Artist affinities and listening history",
+  "sync_collection_subscribed_channels": "Subscriptions",
+  "sync_collection_subscribed_channels_desc": "The channels you follow",
   "sync_collection_subscriptions": "Subscription groups",
-  "sync_collection_subscriptions_desc": "Your channel folders",
+  "sync_collection_subscriptions_desc": "The folders you sort your channels into",
 
   "sync_pair_scan_title": "Scan this with your phone",
   "sync_pair_scan_subtitle": "Open Flow on the other device and scan to receive your data.",

--- a/src/pages/Sync.tsx
+++ b/src/pages/Sync.tsx
@@ -31,6 +31,7 @@ const COLLECTION_STRINGS: Record<string, { title: StringKey; desc: StringKey }> 
   settings: { title: "sync_collection_settings", desc: "sync_collection_settings_desc" },
   flow_neuro_brain: { title: "sync_collection_flow_neuro_brain", desc: "sync_collection_flow_neuro_brain_desc" },
   music_brain: { title: "sync_collection_music_brain", desc: "sync_collection_music_brain_desc" },
+  subscribed_channels: { title: "sync_collection_subscribed_channels", desc: "sync_collection_subscribed_channels_desc" },
   subscriptions: { title: "sync_collection_subscriptions", desc: "sync_collection_subscriptions_desc" },
 };
 

--- a/src/store/useSubscriptionStore.test.ts
+++ b/src/store/useSubscriptionStore.test.ts
@@ -37,12 +37,14 @@ describe("useSubscriptionStore.loadSubscriptions", () => {
 
     await useSubscriptionStore.getState().loadSubscriptions();
 
-    expect(useSubscriptionStore.getState().subscriptions).toEqual([real]);
-    expect(JSON.parse(settings.get("subscriptions") ?? "[]")).toEqual([real]);
+    expect(useSubscriptionStore.getState().subscriptions).toEqual([expect.objectContaining(real)]);
+    expect(JSON.parse(settings.get("subscriptions") ?? "[]")).toEqual([expect.objectContaining(real)]);
   });
 
   it("leaves untouched subscription lists as-is without rewriting them", async () => {
-    const subs = [{ id: "UC1234567890abcdefghijkl", name: "Kept" }];
+    // Already carries a timestamp, so the one-time sync backfill has nothing to do — a load must
+    // still not touch the blob. (The backfill itself is covered below, including that it runs once.)
+    const subs = [{ id: "UC1234567890abcdefghijkl", name: "Kept", subscribedAt: 1781000000000 }];
     settings.set("subscriptions", JSON.stringify(subs));
     const before = settings.get("subscriptions");
 
@@ -50,5 +52,58 @@ describe("useSubscriptionStore.loadSubscriptions", () => {
 
     expect(useSubscriptionStore.getState().subscriptions).toEqual(subs);
     expect(settings.get("subscriptions")).toBe(before);
+  });
+});
+
+describe("useSubscriptionStore unsubscribe tombstones", () => {
+  beforeEach(() => {
+    settings.clear();
+    useSubscriptionStore.setState({ subscriptions: [], subscriptionGroups: [], loading: false });
+  });
+
+  const tombstones = () => JSON.parse(settings.get("subscription_tombstones") ?? "{}");
+
+  it("records an unsubscribe so the next sync does not put the channel back", async () => {
+    await useSubscriptionStore.getState().subscribe("UCx", "Cool");
+    await useSubscriptionStore.getState().unsubscribe("UCx");
+
+    expect(useSubscriptionStore.getState().subscriptions).toEqual([]);
+    expect(Object.keys(tombstones())).toEqual(["UCx"]);
+  });
+
+  it("clears the tombstone when the channel is followed again", async () => {
+    await useSubscriptionStore.getState().subscribe("UCx", "Cool");
+    await useSubscriptionStore.getState().unsubscribe("UCx");
+    await useSubscriptionStore.getState().subscribe("UCx", "Cool");
+
+    expect(tombstones()).toEqual({});
+  });
+
+  it("prunes tombstones past the one-year TTL", async () => {
+    const stale = Date.now() - 400 * 24 * 60 * 60 * 1000;
+    settings.set("subscription_tombstones", JSON.stringify({ UCold: stale }));
+
+    await useSubscriptionStore.getState().subscribe("UCnew", "New");
+    await useSubscriptionStore.getState().unsubscribe("UCnew");
+
+    expect(Object.keys(tombstones())).toEqual(["UCnew"]);
+  });
+
+  it("stamps a subscribe so it can outrank an older unsubscribe from another device", async () => {
+    await useSubscriptionStore.getState().subscribe("UCx", "Cool");
+    const channel = useSubscriptionStore.getState().subscriptions[0];
+
+    expect(channel?.subscribedAt).toBeGreaterThan(0);
+  });
+
+  it("backfills a timestamp onto pre-sync subscriptions exactly once", async () => {
+    settings.set("subscriptions", JSON.stringify([{ id: "UCold", name: "Legacy" }]));
+
+    await useSubscriptionStore.getState().loadSubscriptions();
+    const stamped = useSubscriptionStore.getState().subscriptions[0]?.subscribedAt;
+    expect(stamped).toBeGreaterThan(0);
+
+    await useSubscriptionStore.getState().loadSubscriptions();
+    expect(useSubscriptionStore.getState().subscriptions[0]?.subscribedAt).toBe(stamped);
   });
 });

--- a/src/store/useSubscriptionStore.ts
+++ b/src/store/useSubscriptionStore.ts
@@ -6,7 +6,14 @@ export interface SubscribedChannel {
   name: string;
   avatarUrl?: string;
   subscriberCountText?: string;
+  /** Epoch ms. Doubles as this record's sync clock, so a subscribe/unsubscribe race resolves by
+   *  when each actually happened (FLOW-SYNC/1 §10.0). */
+  subscribedAt?: number;
+  isMusic?: boolean;
 }
+
+/** The subscription fields a metadata refresh may overwrite. */
+type SubscriptionTextField = "name" | "avatarUrl" | "subscriberCountText";
 
 export interface SubscriptionGroup {
   name: string;
@@ -33,6 +40,9 @@ interface SubscriptionState {
 
 const SUBSCRIPTIONS_KEY = "subscriptions";
 const SUBSCRIPTION_GROUPS_KEY = "subscription_groups";
+/** Unsubscribes we still remember, `{channelId: epochMs}` — see `recordUnsubscribe`. */
+const SUBSCRIPTION_TOMBSTONES_KEY = "subscription_tombstones";
+const TOMBSTONE_TTL_MS = 365 * 24 * 60 * 60 * 1000;
 
 const LEGACY_SEED_IDS = new Set(["UCsBjURrdU234nU351gVEfTA", "UCwRxwjk_c_92sAMeX4JzW4w"]);
 
@@ -46,6 +56,42 @@ function cleanGroup(group: SubscriptionGroup, sortOrder: number): SubscriptionGr
     channelIds: Array.from(new Set(group.channelIds.map(cleanChannelId).filter(Boolean))),
     sortOrder,
   };
+}
+
+async function readTombstones(): Promise<Record<string, number>> {
+  try {
+    const raw = await getSetting(SUBSCRIPTION_TOMBSTONES_KEY);
+    const parsed = raw ? (JSON.parse(raw) as Record<string, number>) : {};
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Drop tombstones past the TTL so the store can't grow without bound. */
+function pruneTombstones(tombstones: Record<string, number>, now: number): Record<string, number> {
+  return Object.fromEntries(
+    Object.entries(tombstones).filter(([, at]) => typeof at === "number" && now - at <= TOMBSTONE_TTL_MS),
+  );
+}
+
+/**
+ * Remember an unsubscribe. A channel that is simply absent is indistinguishable from one this
+ * device never followed, so without a tombstone the next sync would put it straight back.
+ */
+async function recordUnsubscribe(channelId: string) {
+  const now = Date.now();
+  const next = pruneTombstones(await readTombstones(), now);
+  next[channelId] = now;
+  await setSetting(SUBSCRIPTION_TOMBSTONES_KEY, JSON.stringify(next));
+}
+
+/** Re-subscribing clears the tombstone, otherwise the peer would keep removing the channel. */
+async function clearTombstone(channelId: string) {
+  const tombstones = await readTombstones();
+  if (!(channelId in tombstones)) return;
+  delete tombstones[channelId];
+  await setSetting(SUBSCRIPTION_TOMBSTONES_KEY, JSON.stringify(pruneTombstones(tombstones, Date.now())));
 }
 
 async function persistSubscriptions(subscriptions: SubscribedChannel[]) {
@@ -71,10 +117,18 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
       const subsJson = await getSetting(SUBSCRIPTIONS_KEY);
       const parsed: SubscribedChannel[] = subsJson ? JSON.parse(subsJson) : [];
       const cleaned = parsed.filter((channel) => !LEGACY_SEED_IDS.has(channel.id));
-      if (cleaned.length !== parsed.length) {
-        await persistSubscriptions(cleaned);
+      // Channels saved before sync existed carry no timestamp, which would read as "epoch" and lose
+      // to any tombstone the peer still holds — silently unsubscribing the user. Stamping them now
+      // is the honest answer (this is when we first knew) and errs toward keeping the subscription.
+      const now = Date.now();
+      const backfilled = cleaned.map((channel) =>
+        channel.subscribedAt ? channel : { ...channel, subscribedAt: now },
+      );
+      const changed = cleaned.length !== parsed.length || backfilled.some((c, i) => c !== cleaned[i]);
+      if (changed) {
+        await persistSubscriptions(backfilled);
       }
-      set({ subscriptions: cleaned, loading: false });
+      set({ subscriptions: backfilled, loading: false });
     } catch (e) {
       console.error("Failed to load subscriptions in store", e);
       set({ loading: false });
@@ -85,13 +139,17 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
     const { subscriptions } = get();
     const cleanId = cleanChannelId(channelId);
     const existing = subscriptions.find((c) => c.id === cleanId);
+    await clearTombstone(cleanId);
     if (existing) {
       if (avatarUrl && !existing.avatarUrl) {
         await get().updateSubscription(cleanId, { avatarUrl });
       }
       return;
     }
-    const updated = [...subscriptions, { id: cleanId, name: channelName, avatarUrl }];
+    const updated = [
+      ...subscriptions,
+      { id: cleanId, name: channelName, avatarUrl, subscribedAt: Date.now() },
+    ];
     set({ subscriptions: updated });
     await persistSubscriptions(updated);
   },
@@ -111,6 +169,7 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
     );
     set({ subscriptions: updated });
     await persistSubscriptions(updated);
+    await recordUnsubscribe(cleanId);
     set({ subscriptionGroups: updatedGroups });
     await persistGroups(updatedGroups);
   },
@@ -135,10 +194,9 @@ export const useSubscriptionStore = create<SubscriptionState>((set, get) => ({
       if (!patch) return channel;
 
       let merged = channel;
-      for (const [key, value] of Object.entries(patch) as [
-        keyof Omit<SubscribedChannel, "id">,
-        string | undefined,
-      ][]) {
+      // Only the display-text fields are patchable here; `subscribedAt`/`isMusic` are set by
+      // subscribe/unsubscribe and by the sync merge, never by a metadata refresh.
+      for (const [key, value] of Object.entries(patch) as [SubscriptionTextField, string | undefined][]) {
         if (value !== undefined && merged[key] !== value) {
           if (merged === channel) merged = { ...channel };
           merged[key] = value;

--- a/src/store/useSyncStore.ts
+++ b/src/store/useSyncStore.ts
@@ -43,6 +43,9 @@ async function applyRefresh(collections: string[]) {
         window.dispatchEvent(new Event(PLAYLIST_LIBRARY_UPDATED_EVENT));
       }
     }
+    if (collections.includes("subscribed_channels")) {
+      await useSubscriptionStore.getState().loadSubscriptions();
+    }
     if (collections.includes("subscriptions")) {
       await useSubscriptionStore.getState().loadSubscriptionGroups();
     }


### PR DESCRIPTION
## Summary

Adds `subscribed_channels` to Flow Sync: the channels you actually follow, not just the folders
you sort them into.

Until now the `subscriptions` collection carried subscription **groups** only. A group's
`channelIds` reached the peer but nothing turned them into real subscriptions, and a group can
express neither a channel that belongs to no group nor an unsubscribe — so the channel list never
transferred at all. This implements the desktop half of `FLOW-SYNC/1` §10.0 (Flow for Android
shipped it first).

Observable behaviour:

- One record per followed channel, merged per-record LWW by HLC with tombstones, so
  subscribe-vs-unsubscribe resolves by *when each actually happened*.
- **Unsubscribes are persisted as tombstones** (`subscription_tombstones`, pruned after 365 days).
  A channel that is simply absent is indistinguishable from one you never followed, so without this
  the peer would put back everything you just unsubscribed from. A tombstone for a channel this
  device never had is kept too, so the removal still reaches a third device.
- **Subscriptions saved before sync existed get a timestamp on first load.** They previously carried
  none, which would read as epoch 0 and lose to any tombstone the peer still holds — silently
  unsubscribing the user. The backfill runs once and is idempotent.
- Device-local fields (`subscriberCountText`) are patched in place rather than rebuilt from the
  wire record, so a sync no longer wipes them.
- The sync picker now lists **Subscriptions** (the channels) and **Subscription groups** (the
  folders) as separate toggles.

Capability version 1, produce + consume. The collection is capability-negotiated, so a peer that
doesn't declare it simply skips it and older Flow for Android keeps syncing groups only.

## Related issue

Closes #46 — the "subscription groups are synced but not the subscriptions themselves" half. (The
brain-decode half of that issue shipped in #59.)

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Build, packaging, or CI

## Validation

Windows 11, x64. Cross-device testing against Flow for Android on the same LAN.

- [x] `pnpm test` — 10 files, 72 tests passed (5 new: tombstone record/clear/TTL prune, subscribe
      stamping, backfill-runs-once)
- [x] `pnpm build` — clean
- [x] `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check` — clean
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features` — 0 errors;
      no new warnings in the touched files
- [x] `cargo test` — 135 tests passed across all 17 integration targets, run individually from
      `src-tauri/`. 11 new: 6 apply-path tests (newer-unsubscribe-wins, older-unsubscribe-loses,
      metadata-not-blanked, third-device tombstone propagation, device-local field preservation,
      idempotent re-apply), CRDT convergence laws, and a `subscribed_channels.json` golden fixture
      with a canonical-bytes lock.
- [x] I smoke-tested the affected desktop behavior — desktop ⇄ Android, both directions:
      subscribes transfer, unsubscribes propagate rather than being re-added.

Note: cargo must be run from inside `src-tauri/` in this repo (it needs `.cargo/config.toml`'s
`reqwest_unstable` rustflag). Invoking it from the repo root via `--manifest-path` builds against
different flags and fails to link `flow_desktop_lib`.

## Screenshots or recordings

<!-- TODO: screenshot of the sync picker showing the two separate entries. -->

## Risk and compatibility

- **No database migration.** The new state is a `settings` row (`subscription_tombstones`); the
  channel list reuses the existing `subscriptions` key.
- **One-time data migration:** `subscribedAt` is backfilled onto existing subscription entries at
  first load and persisted. Idempotent; an already-stamped list is not rewritten.
- **Wire compatibility:** new collection, capability-negotiated at version 1. Peers that don't
  declare it are unaffected — no existing collection's format changed.
- **Backup:** `subscribed_channels` is included in the `APP_DATA` and `MASTER` scopes. The legacy
  `subscription_channels` key is still exported and imported, so existing backup files keep working.
- Unsubscribe tombstones are capped at 365 days on both platforms so the store cannot grow
  unbounded.

- [x] No new secrets, private data, telemetry, or broad Tauri permissions were introduced.
- [x] User-facing documentation was updated where needed.
- [x] Dependency and lockfile changes are intentional and limited to this PR. *(No dependency
      changes in this PR.)*
- [x] Breaking changes and upgrade steps are clearly documented. *(No breaking changes.)*
