### PR TITLE
Feat/UI improvements

### DIFF
--- a/changelog/v0.1.1-beta.txt
+++ b/changelog/v0.1.1-beta.txt
@@ -1,6 +1,6 @@
 FLOW DESKTOP CHANGE LOG
 VERSION: 0.1.1-beta
-DATE: 2026-08-22
+DATE: 2026-08-25
 STATUS: PRE-RELEASE
 
 ABOUT
@@ -21,6 +21,7 @@ LIVESTREAMS
 HOME FEED
 - Fixed the Home feed permanently stopping its auto-loading on scroll after a while, with "Load More" sometimes doing nothing or adding only a couple of videos (#33). Restarting the app did not help, because the feed's search rotation had painted itself into a corner and remembered it; that is fixed too.
 - Clicking "Load More" now always responds, and later pages keep delivering a full batch instead of thinning out.
+- Fixed the row of videos above "Continue watching" splitting onto a second line after changing the videos-per-row setting. It now always shows exactly the number you picked, and drops to fewer only when the window is genuinely too narrow for them.
 
 SUBSCRIPTIONS
 - Removed two placeholder channels (Fireship, Linus Tech Tips) that appeared pre-subscribed on fresh installs and led to a blank page when clicked. Existing installs are cleaned up automatically.
@@ -49,6 +50,7 @@ PLAYER
 - Dislike counts (Return YouTube Dislike) now appear in installed builds; they were blocked by the app's security policy and only worked in development.
 - Fixed external audio dropping out after seeking, pausing, or changing quality.
 - The suggested-videos panel on the watch page scrolls independently of the video, description, and comments.
+- The suggested-videos panel no longer shows a scrollbar down its side.
 - Downloaded music now plays fully offline. The cover art and lyrics already saved with each download are used instead of being fetched again, so tracks start promptly and still show artwork and lyrics with no connection.
 - Smoother scrolling on Home and Subscriptions.
 
@@ -59,14 +61,28 @@ SHORTS
 
 SEARCH
 - More filters on the results page: sort by rating, "Last hour" and "This year" upload windows, a 4-20 minute length option, and a features filter (HD, 4K, Subtitles/CC, Creative Commons, HDR).
+- Fixed the search box offering suggestions for something other than what you had just typed. Any query containing an accent or a non-Latin script failed to load suggestions at all, silently leaving the previous query's list on screen; a slow reply could also overwrite a newer one.
+- Suggestions can now be moved through with the arrow keys, chosen with Enter and dismissed with Escape, and a long list scrolls instead of running off the screen.
 
 MUSIC
 - The mini-player timeline thickens under the cursor and shows a position dot, making it comfortable to scrub.
+- Shuffle and repeat now clearly show when they are on. The button fills with a colour drawn from the current artwork instead of only recolouring the icon, which was easy to miss - and on some tracks invisible against the background.
+- New Music Player Background setting with four styles - Blur + Gradient, Blurred Artwork, Palette Gradient and Default Surface - matching Flow for Android.
+
+INTERFACE
+- Hovering a card now grows its artwork colour outward from the centre rather than simply switching it on, with a softer, springier transition.
+- That artwork-coloured hover reaches the cards that never had it: playlists, music albums and artists, channels, and the videos listed inside a playlist.
+- Fixed the hover colour being clipped at the edges of shelves and rows - noticeably on the first card of a row - on Home, History, Library, the music and artist pages, and the suggested-videos panel.
+- Every shelf now has left and right arrows for moving through it. The music, Library and Subscriptions shelves had none, and the ones that did have them did not all look the same.
+- Toggle switches have been redesigned: larger, with a tick when on and a cross when off, and they react to being pressed.
+- Buttons across the app now respond to a click the way the player's controls always have.
+- Volume, the equaliser and the music player's seek bar use a new slider design with a thicker track and a slim handle. If you prefer the old one, turn off Settings > Appearance > Expressive sliders. The video, Shorts and mini-player seek bars are unchanged.
 
 BACKUPS AND DATA
 - Backups now actually contain your data. Previously a Flow backup file held only settings - watch history, subscriptions, playlists, likes, and the recommendation brains were silently left out, which is why restores came back crippled. The App data / Brain / Everything choice now does exactly what it says, and restoring shows a summary of what came back.
 - Fixed restoring a backup being able to leave Deep Flow silently stuck on forever, which stopped watch-history recording and FlowNeuro learning without any visible sign.
 - The Reset Brain confirmation now appears centred on screen instead of buried in the middle of the page.
+- The Import data page was rebuilt to match the rest of Settings, and its in-page back button removed now that the top bar handles going back.
 
 DOWNLOADS
 - New thumbnail options in Settings: turn artwork saving on or off, and choose between a separate image file, embedding it in the media file, or both. Music and audio downloads embed cover art directly; video downloads always use a separate file.

--- a/src-tauri/src/api/innertube/extractors/search.rs
+++ b/src-tauri/src/api/innertube/extractors/search.rs
@@ -1,10 +1,10 @@
+use crate::api::http::shared_client;
 use crate::api::innertube::InnertubeClient;
 use crate::api::innertube::core::clients;
 use crate::api::innertube::core::utils::{
     detect_video_is_live, extract_channel_id_from_video_renderer, extract_continuation_token,
     normalize_youtube_image_url, parse_duration_seconds,
 };
-use crate::api::http::shared_client;
 use crate::api::innertube::parsers::parse_music_search_json;
 use crate::errors::{AppError, AppResult};
 use crate::models::search::{SearchVideosRequest, SearchVideosResponse};
@@ -370,7 +370,9 @@ impl InnertubeClient {
                 let cleaned = text.trim();
                 // The endpoint repeats entries that differ only by casing or spacing.
                 if cleaned.is_empty()
-                    || suggestions.iter().any(|existing| existing.eq_ignore_ascii_case(cleaned))
+                    || suggestions
+                        .iter()
+                        .any(|existing| existing.eq_ignore_ascii_case(cleaned))
                 {
                     continue;
                 }

--- a/src-tauri/src/api/innertube/extractors/search.rs
+++ b/src-tauri/src/api/innertube/extractors/search.rs
@@ -4,6 +4,7 @@ use crate::api::innertube::core::utils::{
     detect_video_is_live, extract_channel_id_from_video_renderer, extract_continuation_token,
     normalize_youtube_image_url, parse_duration_seconds,
 };
+use crate::api::http::shared_client;
 use crate::api::innertube::parsers::parse_music_search_json;
 use crate::errors::{AppError, AppResult};
 use crate::models::search::{SearchVideosRequest, SearchVideosResponse};
@@ -333,13 +334,15 @@ impl InnertubeClient {
 
     pub async fn get_search_suggestions(&self, query: &str) -> AppResult<Vec<String>> {
         let encoded_query = custom_url_encode(query);
+        // `oe=utf-8` is load-bearing: without it this endpoint answers in
+        // ISO-8859-1, and every suggestion carrying an accent, a curly quote or
+        // any non-Latin script comes back as mojibake.
         let url = format!(
-            "https://suggestqueries-clients6.youtube.com/complete/search?client=youtube&ds=yt&xhr=t&q={}",
+            "https://suggestqueries-clients6.youtube.com/complete/search?client=youtube&ds=yt&xhr=t&ie=utf-8&oe=utf-8&q={}",
             encoded_query
         );
 
-        let client = reqwest::Client::new();
-        let res = client
+        let res = shared_client()
             .get(&url)
             .header("Origin", "https://www.youtube.com")
             .header("Referer", "https://www.youtube.com")
@@ -347,20 +350,31 @@ impl InnertubeClient {
             .await
             .map_err(|e| AppError::Extractor(format!("Network error suggestions: {}", e)))?;
 
-        let val: Value = res
-            .json()
+        // Decoded through `text()` rather than `json()` on purpose: it honours the
+        // charset the response declares, so a legacy encoding still decodes instead
+        // of failing the whole request on bytes that are not valid UTF-8.
+        let body = res
+            .text()
             .await
+            .map_err(|e| AppError::Extractor(format!("Read error suggestions: {}", e)))?;
+
+        let val: Value = serde_json::from_str(&body)
             .map_err(|e| AppError::Extractor(format!("JSON error suggestions: {}", e)))?;
 
-        let mut suggestions = Vec::new();
+        let mut suggestions: Vec<String> = Vec::new();
         if let Some(arr) = val.get(1).and_then(|v| v.as_array()) {
             for item in arr {
-                if let Some(suggestion_str) = item.get(0).and_then(|s| s.as_str()) {
-                    let cleaned = suggestion_str.trim().to_string();
-                    if !cleaned.is_empty() {
-                        suggestions.push(cleaned);
-                    }
+                let Some(text) = item.get(0).and_then(|s| s.as_str()) else {
+                    continue;
+                };
+                let cleaned = text.trim();
+                // The endpoint repeats entries that differ only by casing or spacing.
+                if cleaned.is_empty()
+                    || suggestions.iter().any(|existing| existing.eq_ignore_ascii_case(cleaned))
+                {
+                    continue;
                 }
+                suggestions.push(cleaned.to_string());
             }
         }
         Ok(suggestions)

--- a/src/App.css
+++ b/src/App.css
@@ -295,6 +295,12 @@
   .music-wave-bar {
     animation: none;
   }
+
+  /* The wash animates through inline styles, so reduced motion has to outrank them. */
+  .color-wash {
+    transform: none !important;
+    transition: opacity 120ms linear !important;
+  }
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */

--- a/src/App.css
+++ b/src/App.css
@@ -303,6 +303,178 @@
   }
 }
 
+/*
+  Material 3 Expressive slider.
+
+  The 3px handle sits inside a 6px gap cut out of the track, and that gap has to
+  show the surface behind it rather than a colour — so the two track segments are
+  positioned off `--m3-fill` (0..1) instead of being painted as one gradient.
+  Handle position is measured from its centre so narrowing it on press stays
+  symmetric.
+*/
+.m3-slider {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 1.75rem;
+  touch-action: none;
+}
+
+.m3-slider__track {
+  position: absolute;
+  height: 0.75rem;
+  border-radius: 9999px;
+}
+
+.m3-slider__track--active {
+  left: 0;
+  width: max(0px, calc(var(--m3-fill) * (100% - 3px) - 6px));
+  background-color: var(--color-primary);
+}
+
+.m3-slider__track--inactive {
+  left: calc(var(--m3-fill) * (100% - 3px) + 9px);
+  right: 0;
+  background-color: var(--color-surface-container-highest);
+}
+
+.m3-slider__handle {
+  position: absolute;
+  left: calc(1.5px + var(--m3-fill) * (100% - 3px));
+  transform: translateX(-50%);
+  width: 3px;
+  height: 1.5rem;
+  border-radius: 9999px;
+  background-color: var(--color-primary);
+  transition: width 120ms ease-out;
+}
+
+.m3-slider[data-pressed="true"] .m3-slider__handle {
+  width: 2px;
+}
+
+/* Marks the end of travel; pointless once the handle has reached it. */
+.m3-slider__stop {
+  position: absolute;
+  right: 6px;
+  width: 3px;
+  height: 3px;
+  border-radius: 9999px;
+  background-color: var(--color-primary);
+}
+
+/* The real control: invisible, but keeps native dragging, keyboard and a11y. */
+.m3-slider__input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.m3-slider__input:disabled {
+  cursor: not-allowed;
+}
+
+.m3-slider[data-disabled="true"] {
+  opacity: 0.5;
+}
+
+/* Progressive enhancement — `:has()` is missing on older WebKitGTK builds. */
+.m3-slider:has(.m3-slider__input:focus-visible) .m3-slider__handle {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+/*
+  Vertical variant (EQ bands). Same geometry rotated: the fill grows from the
+  bottom, so every offset is measured from `bottom` instead of `left`. The
+  hidden input keeps the writing-mode pair the EQ sliders already used, which is
+  what makes a native range drag bottom-to-top.
+*/
+.m3-slider--vertical {
+  width: 1.25rem;
+  height: 6.5rem;
+  justify-content: center;
+}
+
+.m3-slider--vertical .m3-slider__track {
+  left: 50%;
+  height: auto;
+  width: 0.75rem;
+  transform: translateX(-50%);
+}
+
+.m3-slider--vertical .m3-slider__track--active {
+  top: auto;
+  bottom: 0;
+  height: max(0px, calc(var(--m3-fill) * (100% - 3px) - 6px));
+}
+
+.m3-slider--vertical .m3-slider__track--inactive {
+  top: 0;
+  left: 50%;
+  right: auto;
+  bottom: calc(var(--m3-fill) * (100% - 3px) + 9px);
+}
+
+.m3-slider--vertical .m3-slider__handle {
+  left: 50%;
+  top: auto;
+  bottom: calc(1.5px + var(--m3-fill) * (100% - 3px));
+  width: 1.25rem;
+  height: 3px;
+  transform: translate(-50%, 50%);
+  transition: height 120ms ease-out;
+}
+
+.m3-slider--vertical[data-pressed="true"] .m3-slider__handle {
+  width: 1.25rem;
+  height: 2px;
+}
+
+.m3-slider--vertical .m3-slider__stop {
+  right: auto;
+  left: 50%;
+  top: 6px;
+  transform: translateX(-50%);
+}
+
+.m3-slider--vertical .m3-slider__input {
+  writing-mode: vertical-lr;
+  direction: rtl;
+}
+
+/* The pre-expressive look, kept for the Settings opt-out. */
+.m3-slider-legacy {
+  width: 100%;
+  height: 0.25rem;
+  accent-color: var(--color-primary);
+  cursor: pointer;
+}
+
+.m3-slider-legacy--vertical {
+  writing-mode: vertical-lr;
+  direction: rtl;
+  width: 1.25rem;
+  height: 6.5rem;
+  background: transparent;
+}
+
+.m3-slider-legacy:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .m3-slider__handle {
+    transition: none;
+  }
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .scrollbar-none::-webkit-scrollbar {
   display: none;
@@ -345,22 +517,6 @@
   max-width: none !important;
   max-height: none !important;
   object-fit: contain !important;
-}
-
-.eq-range {
-  writing-mode: vertical-lr;
-  direction: rtl;
-  width: 1.25rem;
-  height: 6.5rem;
-  accent-color: var(--color-primary);
-  cursor: pointer;
-  background: transparent;
-}
-
-.eq-range:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-  border-radius: 9999px;
 }
 
 /*

--- a/src/components/channel/ChannelCard.tsx
+++ b/src/components/channel/ChannelCard.tsx
@@ -6,6 +6,8 @@ import { Button } from '../ui/Button';
 import { getString } from '../../lib/i18n/index';
 import { upgradeAvatarUrl } from '../../lib/thumbnails';
 import { useProxiedImageUrl } from '../../lib/useProxiedImageUrl';
+import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
+import { useHoverWashColor } from '../../lib/useHoverWashColor';
 
 export interface ChannelCardProps {
   channelId: string;
@@ -51,6 +53,8 @@ export function ChannelCard({
   className,
 }: ChannelCardProps) {
   const navigate = useNavigate();
+  const washSrc = useProxiedImageUrl(upgradeAvatarUrl(avatarUrl));
+  const wash = useHoverWashColor(washSrc);
   const cleanId = channelId.replace('channel:', '');
   const isSubscribed = useSubscriptionStore((s) => s.isSubscribed);
   const subscribe = useSubscriptionStore((s) => s.subscribe);
@@ -82,12 +86,15 @@ export function ChannelCard({
           open();
         }
       }}
+      onMouseEnter={wash.onMouseEnter}
+      onMouseLeave={wash.onMouseLeave}
       className={cx(
-        'group flex cursor-pointer flex-col items-center gap-3 rounded-2xl text-center outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
+        `group ${COLOR_WASH_HOST} flex cursor-pointer flex-col items-center gap-3 rounded-2xl text-center outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]`,
         fill ? 'w-full' : 'w-40 md:w-48',
         className,
       )}
     >
+      <ColorWash active={wash.isHovered} color={wash.color} radius="rounded-2xl" bleed={6} />
       <div className="aspect-square w-full">
         <div className="h-full w-full overflow-hidden rounded-full ring-1 ring-chrome-neutral-800/50 transition-transform duration-200 ease-out group-hover:scale-[1.02]">
           <CircleAvatar src={avatarUrl} name={name} />

--- a/src/components/donations/DonationPrompt.tsx
+++ b/src/components/donations/DonationPrompt.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Heart } from "lucide-react";
 import { getString } from "../../lib/i18n/index";
+import { Button } from "../ui/Button";
 import {
   DONATION_PROMPT_SHOW_DELAY_MS,
   disableDonationPrompt,
@@ -115,30 +116,18 @@ function DonationPromptDialog({
         </div>
 
         <div className="mt-6 flex flex-col gap-1.5">
-          <button
-            type="button"
-            onClick={onSupport}
-            className="inline-flex items-center justify-center gap-2 rounded-full bg-[var(--color-primary)] px-4 py-3 text-sm font-semibold text-[var(--color-on-primary)] transition-opacity duration-200 ease-out hover:opacity-90"
-          >
+          <Button onClick={onSupport} className="font-semibold">
             <Heart className="h-4 w-4" />
             {getString("donation_prompt_support")}
-          </button>
+          </Button>
 
-          <button
-            type="button"
-            onClick={onLater}
-            className="rounded-full px-4 py-2.5 text-sm font-medium text-chrome-neutral-300 transition-colors duration-200 ease-out hover:bg-surface-container-high"
-          >
+          <Button variant="ghost" onClick={onLater}>
             {getString("donation_prompt_later")}
-          </button>
+          </Button>
 
-          <button
-            type="button"
-            onClick={onNever}
-            className="rounded-full px-4 py-2.5 text-sm font-medium text-chrome-neutral-500 transition-colors duration-200 ease-out hover:bg-surface-container-high hover:text-chrome-neutral-300"
-          >
+          <Button variant="ghost" onClick={onNever} className="text-chrome-neutral-500 hover:text-chrome-neutral-300">
             {getString("donation_prompt_never")}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -18,6 +18,7 @@ export function Topbar() {
   const [localSearch, setLocalSearch] = useState('');
   const [suggestions, setSuggestions] = useState<string[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
+  const [activeSuggestion, setActiveSuggestion] = useState(-1);
   const [resolving, setResolving] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
@@ -51,22 +52,76 @@ export function Topbar() {
   }, []);
 
   useEffect(() => {
-    if (localSearch.trim().length < 2) {
+    const query = localSearch.trim();
+    if (query.length < 2) {
       setSuggestions([]);
       return;
     }
 
+    // Responses can land out of order, and clearing the timeout does not cancel a
+    // request already in flight. Without this guard a slow reply for an earlier
+    // keystroke overwrites the current one, which reads as suggestions that have
+    // nothing to do with what was typed.
+    let current = true;
+
     const delay = setTimeout(async () => {
       try {
-        const res = await getSearchSuggestions(localSearch);
-        setSuggestions(res.slice(0, 6));
-      } catch (err) {
-        console.warn("Suggestions error", err);
+        const results = await getSearchSuggestions(query);
+        if (!current) return;
+        setSuggestions(results.slice(0, 8));
+      } catch (error) {
+        console.warn("Suggestions error", error);
+        // Leaving the previous query's results on screen is worse than none.
+        if (current) setSuggestions([]);
       }
     }, 250);
 
-    return () => clearTimeout(delay);
+    return () => {
+      current = false;
+      clearTimeout(delay);
+    };
   }, [localSearch]);
+
+  // A changed result set invalidates whatever row the keyboard was on.
+  useEffect(() => setActiveSuggestion(-1), [suggestions]);
+
+  const commitSuggestion = (suggestion: string) => {
+    setLocalSearch(suggestion);
+    setSearchQuery(suggestion);
+    setShowSuggestions(false);
+    setActiveSuggestion(-1);
+    navigate(`/search?q=${encodeURIComponent(suggestion)}`);
+  };
+
+  const handleSearchKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      setShowSuggestions(false);
+      setActiveSuggestion(-1);
+      return;
+    }
+    if (!showSuggestions || suggestions.length === 0) return;
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      setActiveSuggestion((current) => {
+        const next = current + step;
+        if (next < 0) return suggestions.length - 1;
+        if (next >= suggestions.length) return 0;
+        return next;
+      });
+      return;
+    }
+
+    // Enter on a highlighted row runs that suggestion; otherwise the form submits.
+    if (event.key === "Enter" && activeSuggestion >= 0) {
+      const picked = suggestions[activeSuggestion];
+      if (picked) {
+        event.preventDefault();
+        commitSuggestion(picked);
+      }
+    }
+  };
 
   const runTextSearch = (query: string) => {
     setSearchQuery(query);
@@ -163,7 +218,13 @@ export function Topbar() {
               type="text"
               placeholder="Search"
               value={localSearch}
+              role="combobox"
+              aria-expanded={showSuggestions && suggestions.length > 0}
+              aria-controls="search-suggestions"
+              aria-activedescendant={activeSuggestion >= 0 ? `search-suggestion-${activeSuggestion}` : undefined}
+              autoComplete="off"
               onFocus={() => setShowSuggestions(true)}
+              onKeyDown={handleSearchKeyDown}
               onChange={(e) => {
                 setLocalSearch(e.target.value);
                 setShowSuggestions(true);
@@ -186,20 +247,27 @@ export function Topbar() {
 
         {/* Suggestion Dropdown overlay */}
         {showSuggestions && suggestions.length > 0 && (
-          <div className="absolute left-4 right-4 top-[48px] z-50 overflow-hidden rounded-2xl border border-chrome-zinc-800 bg-chrome-dropdown md:left-8 md:right-8">
-            {suggestions.map((item, idx) => (
+          <div
+            id="search-suggestions"
+            role="listbox"
+            className="absolute left-4 right-4 top-[48px] z-50 max-h-[60vh] overflow-y-auto overscroll-contain rounded-2xl border border-chrome-zinc-800 bg-chrome-dropdown py-1 scrollbar-none md:left-8 md:right-8"
+          >
+            {suggestions.map((item, index) => (
               <div
-                key={idx}
-                onClick={() => {
-                  setLocalSearch(item);
-                  setSearchQuery(item);
-                  setShowSuggestions(false);
-                  navigate(`/search?q=${encodeURIComponent(item)}`);
-                }}
-                className="flex cursor-pointer items-center gap-3 px-5 py-3 text-sm font-medium text-chrome-zinc-200 transition-colors hover:bg-chrome-zinc-800"
+                key={item}
+                id={`search-suggestion-${index}`}
+                role="option"
+                aria-selected={index === activeSuggestion}
+                // Keep focus in the input so the caret and keyboard stay live.
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setActiveSuggestion(index)}
+                onClick={() => commitSuggestion(item)}
+                className={`flex cursor-pointer items-center gap-3 px-5 py-3 text-sm font-medium text-chrome-zinc-200 transition-colors ${
+                  index === activeSuggestion ? "bg-chrome-zinc-800" : ""
+                }`}
               >
-                <Search className="h-3.5 w-3.5 text-chrome-zinc-500" />
-                {item}
+                <Search className="h-3.5 w-3.5 shrink-0 text-chrome-zinc-500" />
+                <span className="min-w-0 truncate">{item}</span>
               </div>
             ))}
           </div>

--- a/src/components/library/LibraryShelf.tsx
+++ b/src/components/library/LibraryShelf.tsx
@@ -63,7 +63,7 @@ export const LibraryShelf: React.FC<LibraryShelfProps> = ({
           </p>
         </div>
       ) : (
-        <div className="flex gap-4 overflow-x-auto snap-x hide-scrollbar pb-4">
+        <div className="flex gap-4 overflow-x-auto snap-x hide-scrollbar px-3 -mx-3 pt-3 -mt-2 pb-4">
           {children}
         </div>
       )}

--- a/src/components/library/LibraryShelf.tsx
+++ b/src/components/library/LibraryShelf.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 import { getString } from "../../lib/i18n/index";
+import { Button } from "../ui/Button";
 
 interface LibraryShelfProps {
   /** Section heading, e.g. "History". */
@@ -44,14 +45,10 @@ export const LibraryShelf: React.FC<LibraryShelfProps> = ({
           {title}
         </h2>
 
-        <button
-          type="button"
-          onClick={() => navigate(viewAllTo)}
-          className="flex items-center gap-1 rounded-full bg-surface-container-high px-4 py-1.5 text-sm font-medium text-chrome-neutral-200 transition-colors duration-200 ease-out hover:bg-surface-container-highest"
-        >
+        <Button variant="secondary" size="sm" onClick={() => navigate(viewAllTo)} className="gap-1 px-4 text-sm">
           {getString("library_view_all")}
           <ChevronRight className="h-4 w-4" />
-        </button>
+        </Button>
       </div>
 
       {/* Shelf body — swiper of cards, or the MD3 empty state */}

--- a/src/components/library/LibraryShelf.tsx
+++ b/src/components/library/LibraryShelf.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 import { getString } from "../../lib/i18n/index";
 import { Button } from "../ui/Button";
+import { ShelfScroller } from "../ui/ShelfScroller";
 
 interface LibraryShelfProps {
   /** Section heading, e.g. "History". */
@@ -60,9 +61,9 @@ export const LibraryShelf: React.FC<LibraryShelfProps> = ({
           </p>
         </div>
       ) : (
-        <div className="flex gap-4 overflow-x-auto snap-x hide-scrollbar px-3 -mx-3 pt-3 -mt-2 pb-4">
+        <ShelfScroller className="flex gap-4 snap-x px-3 -mx-3 pt-3 -mt-2 pb-4">
           {children}
-        </div>
+        </ShelfScroller>
       )}
     </section>
   );

--- a/src/components/music/AddToAlbumModal.tsx
+++ b/src/components/music/AddToAlbumModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Disc3, Music2, Plus, X } from "lucide-react";
 import { getString } from "../../lib/i18n/index";
+import { Button } from "../ui/Button";
 import { upgradeMusicImageUrl } from "../../lib/thumbnails";
 import { useProxiedImageUrl } from "../../lib/useProxiedImageUrl";
 import { useAlbumLibraryStore, type StoredAlbum } from "../../store/useAlbumLibraryStore";
@@ -125,20 +126,23 @@ export function AddToAlbumModal() {
               className="w-full rounded-lg border border-chrome-neutral-800 bg-surface-container-low px-3 py-2 text-sm text-chrome-neutral-100 outline-none transition-colors placeholder:text-chrome-neutral-500 focus:border-chrome-neutral-700"
             />
             <div className="flex items-center justify-end gap-2">
-              <button
+              <Button
                 type="button"
                 onClick={() => setCreating(false)}
-                className="rounded-full px-3 py-1.5 text-sm font-medium text-chrome-neutral-300 transition-colors hover:bg-surface-container-high"
+                variant="ghost"
+                size="sm"
+                className="text-sm text-chrome-neutral-300"
               >
                 {getString("cancel")}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 disabled={!newName.trim()}
-                className="rounded-full bg-[var(--color-primary)] px-4 py-1.5 text-sm font-medium text-[var(--color-on-primary)] transition-colors hover:opacity-90 disabled:opacity-50"
+                size="sm"
+                className="px-4 text-sm"
               >
                 {getString("albums_create")}
-              </button>
+              </Button>
             </div>
           </form>
         ) : (

--- a/src/components/music/AlbumTrackRow.tsx
+++ b/src/components/music/AlbumTrackRow.tsx
@@ -5,6 +5,7 @@ import { getString } from '../../lib/i18n/index';
 import { artistsText, formatTime } from '../../lib/musicFormat';
 import { upgradeMusicImageUrl } from '../../lib/thumbnails';
 import { extractDominantColorFromImage, useDominantColor } from '../../lib/useDominantColor';
+import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
 import { useProxiedImageUrl } from '../../lib/useProxiedImageUrl';
 import { useMusicPlayerStore } from '../../store/useMusicPlayerStore';
 import { useAlbumLibraryStore } from '../../store/useAlbumLibraryStore';
@@ -48,11 +49,6 @@ function ExplicitBadge() {
       E
     </span>
   );
-}
-
-function colorBackground(color: { r: number; g: number; b: number } | null): React.CSSProperties {
-  if (!color) return { background: 'color-mix(in srgb, var(--color-chrome-zinc-800) 50%, transparent)' };
-  return { background: `rgba(${color.r}, ${color.g}, ${color.b}, 0.22)` };
 }
 
 function videoIdOf(track: SongItem): string {
@@ -257,11 +253,11 @@ export function AlbumTrackRow({
           onPlay(track);
         }
       }}
-      style={isHighlighted ? colorBackground(activeColor) : undefined}
       className={`group flex cursor-pointer items-center rounded-lg px-4 py-2 transition-colors duration-200 ease-out ${
         isCurrent ? 'bg-surface-container-low' : ''
-      } relative`}
+      } ${COLOR_WASH_HOST}`}
     >
+      <ColorWash active={isHighlighted} color={activeColor} radius="rounded-lg" spread="row" />
       <div className="relative grid w-12 shrink-0 place-items-center">
         {showEq ? (
           <PlayingWave className="text-[var(--color-primary)]" />

--- a/src/components/music/AmbientBackdrop.tsx
+++ b/src/components/music/AmbientBackdrop.tsx
@@ -1,20 +1,77 @@
+import type { CSSProperties } from "react";
 import type { Rgb } from "../../lib/useDominantColor";
 import { upgradeMusicImageUrl } from "../../lib/thumbnails";
 
-export function AmbientBackdrop({ src, accent }: { src?: string | null; accent?: Rgb | null }) {
+/**
+ * Ported from the Android player's `MusicPlayerBackgroundStyle`, so a user who
+ * runs both apps gets the same four choices under the same names.
+ */
+export type MusicBackgroundStyle = "blur_gradient" | "blur" | "gradient" | "default";
+
+export const MUSIC_BACKGROUND_STYLES: readonly MusicBackgroundStyle[] = [
+  "blur_gradient",
+  "blur",
+  "gradient",
+  "default",
+];
+
+export function isMusicBackgroundStyle(value: string): value is MusicBackgroundStyle {
+  return (MUSIC_BACKGROUND_STYLES as readonly string[]).includes(value);
+}
+
+/** The palette tint, at the two weights the gradients mix between. */
+function tint(accent: Rgb | null | undefined, alpha: number): string {
+  if (!accent) return `rgba(0, 0, 0, ${alpha})`;
+  return `rgba(${accent.r}, ${accent.g}, ${accent.b}, ${alpha})`;
+}
+
+function gradientFor(style: MusicBackgroundStyle, accent: Rgb | null | undefined): CSSProperties | null {
+  switch (style) {
+    // Artwork carries the colour here; the wash only has to keep text legible.
+    case "blur_gradient":
+      return {
+        background: `linear-gradient(to bottom, rgba(0,0,0,0.40) 0%, ${tint(accent, 0.22)} 30%, ${tint(accent, 0.34)} 55%, rgba(0,0,0,0.80) 80%, rgba(0,0,0,0.95) 100%)`,
+      };
+    case "blur":
+      return { background: "rgba(0, 0, 0, 0.58)" };
+    // No artwork behind it, so the palette runs much stronger at the top.
+    case "gradient":
+      return {
+        background: `linear-gradient(to bottom, ${tint(accent, 0.72)} 0%, ${tint(accent, 0.78)} 38%, rgba(0,0,0,0.88) 72%, rgb(0,0,0) 100%)`,
+      };
+    case "default":
+      return {
+        background: `linear-gradient(to bottom, rgb(0,0,0) 0%, ${tint(accent, 0.22)} 45%, rgb(0,0,0) 100%)`,
+      };
+  }
+}
+
+interface AmbientBackdropProps {
+  src?: string | null;
+  accent?: Rgb | null;
+  style?: MusicBackgroundStyle;
+}
+
+export function AmbientBackdrop({ src, accent, style = "blur_gradient" }: AmbientBackdropProps) {
   const imageSrc = upgradeMusicImageUrl(src);
+  const showArtwork = style === "blur_gradient" || style === "blur";
+  const overlay = gradientFor(style, accent);
+
   return (
     <div className="pointer-events-none absolute inset-0 z-0 overflow-hidden bg-chrome-neutral-950">
-      {imageSrc && (
+      {showArtwork && imageSrc && (
         <img
           key={imageSrc}
           src={imageSrc}
           alt=""
           aria-hidden
-          className="absolute inset-0 h-full w-full scale-125 object-cover opacity-30 blur-[100px] saturate-150"
+          className={`absolute inset-0 h-full w-full scale-125 object-cover blur-[100px] saturate-150 ${
+            style === "blur" ? "opacity-60" : "opacity-30"
+          }`}
         />
       )}
-      {accent && (
+
+      {style === "blur_gradient" && accent && (
         <div
           className="absolute inset-0"
           style={{
@@ -22,7 +79,8 @@ export function AmbientBackdrop({ src, accent }: { src?: string | null; accent?:
           }}
         />
       )}
-      <div className="absolute inset-0 bg-linear-to-b from-chrome-neutral-950/40 via-chrome-neutral-950/60 to-chrome-neutral-950" />
+
+      {overlay && <div className="absolute inset-0" style={overlay} />}
     </div>
   );
 }

--- a/src/components/music/ArtistCard.tsx
+++ b/src/components/music/ArtistCard.tsx
@@ -7,6 +7,8 @@ import { Button } from '../ui/Button';
 import { getString } from '../../lib/i18n/index';
 import { upgradeAvatarUrl } from '../../lib/thumbnails';
 import { useProxiedImageUrl } from '../../lib/useProxiedImageUrl';
+import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
+import { useHoverWashColor } from '../../lib/useHoverWashColor';
 
 export interface ArtistCardProps {
   artist: ArtistItem;
@@ -43,6 +45,8 @@ function CircleAvatar({ src, name }: { src?: string | null; name: string }) {
 
 export function ArtistCard({ artist, fill, className, onOpen }: ArtistCardProps) {
   const navigate = useNavigate();
+  const washSrc = useProxiedImageUrl(upgradeAvatarUrl(artist.thumbnail));
+  const wash = useHoverWashColor(washSrc);
   const target = (artist.channelId || artist.id || '').replace('channel:', '');
   const isSubscribed = useSubscriptionStore((s) => s.isSubscribed);
   const subscribe = useSubscriptionStore((s) => s.subscribe);
@@ -78,12 +82,15 @@ export function ArtistCard({ artist, fill, className, onOpen }: ArtistCardProps)
           open();
         }
       }}
+      onMouseEnter={wash.onMouseEnter}
+      onMouseLeave={wash.onMouseLeave}
       className={cx(
-        'group flex cursor-pointer flex-col items-center gap-3 rounded-2xl text-center outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
+        `group ${COLOR_WASH_HOST} flex cursor-pointer flex-col items-center gap-3 rounded-2xl text-center outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]`,
         fill ? 'w-full' : 'w-40 md:w-48',
         className,
       )}
     >
+      <ColorWash active={wash.isHovered} color={wash.color} radius="rounded-2xl" bleed={6} />
       <div className="aspect-square w-full">
         <div className="h-full w-full overflow-hidden rounded-full ring-1 ring-chrome-neutral-800/50 transition-transform duration-200 ease-out group-hover:scale-[1.02]">
           <CircleAvatar src={artist.thumbnail} name={artist.title} />

--- a/src/components/music/EqPanel.tsx
+++ b/src/components/music/EqPanel.tsx
@@ -11,6 +11,7 @@ import {
 import { ToggleSwitch } from "../ui/ToggleSwitch";
 import { Chip } from "../ui/Chip";
 import { getString } from "../../lib/i18n/index";
+import { Slider } from "../ui/Slider";
 
 const PRESETS: EqPresetName[] = ["flat", "bass", "vocal", "treble", "electronic", "acoustic"];
 
@@ -96,14 +97,13 @@ export function EqPanel({
                 <span className="font-mono text-[10px] tabular-nums text-chrome-neutral-500">
                   {formatGain(eqGains[i])}
                 </span>
-                <input
-                  type="range"
-                  className="eq-range"
+                <Slider
+                  orientation="vertical"
                   min={-EQ_MAX_GAIN_DB}
                   max={EQ_MAX_GAIN_DB}
                   step={1}
                   value={eqGains[i] ?? 0}
-                  onChange={(e) => setEqBand(i, Number(e.target.value))}
+                  onChange={(gain) => setEqBand(i, gain)}
                   aria-label={`${band.label} Hz`}
                 />
                 <span className="text-[10px] text-chrome-neutral-500">{band.label}</span>

--- a/src/components/music/GlobalMusicDock.tsx
+++ b/src/components/music/GlobalMusicDock.tsx
@@ -28,10 +28,13 @@ import { MusicArtwork } from "./MusicArtwork";
 import { MusicScrubber } from "./MusicScrubber";
 import { EqPanel } from "./EqPanel";
 import { VolumePopover } from "./VolumePopover";
+import { useDominantColor } from "../../lib/useDominantColor";
+import { accentForeground, accentSurface } from "../../lib/accentColor";
+import { upgradeMusicImageUrl } from "../../lib/thumbnails";
+import { useProxiedImageUrl } from "../../lib/useProxiedImageUrl";
 
 const GHOST = "grid h-9 w-9 place-items-center rounded-full transition-colors duration-200 ease-out";
 const GHOST_IDLE = `${GHOST} text-chrome-neutral-400 hover:text-chrome-neutral-100`;
-const GHOST_ACTIVE = `${GHOST} text-[var(--color-primary)]`;
 
 export function GlobalMusicDock() {
   const currentTrack = useMusicPlayerStore((s) => s.currentTrack);
@@ -56,6 +59,14 @@ export function GlobalMusicDock() {
   const { errorInfo, onRetry, onCopyLogs, onOpenInBrowser } = useMusicPlayerError();
 
   const [popover, setPopover] = useState<null | "eq" | "vol">(null);
+
+  // Same artwork URL the overlay samples, so this reads a warm cache entry.
+  const accentSrc = useProxiedImageUrl(upgradeMusicImageUrl(currentTrack?.thumbnail));
+  const accent = useDominantColor(accentSrc);
+  const accentActive = {
+    color: accentForeground(accent),
+    backgroundColor: accentSurface(accent),
+  };
 
   const loading = isBuffering || loadingStreamId !== null;
   const muted = isMuted || volume === 0;
@@ -127,7 +138,8 @@ export function GlobalMusicDock() {
                 onClick={toggleShuffle}
                 aria-label={getString("music_shuffle")}
                 aria-pressed={isShuffle}
-                className={isShuffle ? GHOST_ACTIVE : GHOST_IDLE}
+                className={isShuffle ? GHOST : GHOST_IDLE}
+                style={isShuffle ? accentActive : undefined}
               >
                 <Shuffle className="h-[18px] w-[18px]" />
               </HapticButton>
@@ -168,7 +180,8 @@ export function GlobalMusicDock() {
                   repeatMode === "one" ? getString("music_repeat_one") : getString("music_repeat")
                 }
                 aria-pressed={repeatMode !== "none"}
-                className={repeatMode !== "none" ? GHOST_ACTIVE : GHOST_IDLE}
+                className={repeatMode !== "none" ? GHOST : GHOST_IDLE}
+                style={repeatMode !== "none" ? accentActive : undefined}
               >
                 {repeatMode === "one" ? (
                   <Repeat1 className="h-[18px] w-[18px]" />
@@ -209,7 +222,8 @@ export function GlobalMusicDock() {
                 onClick={() => setPopover((p) => (p === "eq" ? null : "eq"))}
                 aria-label={getString("music_equalizer")}
                 aria-pressed={popover === "eq"}
-                className={popover === "eq" || eqEnabled ? GHOST_ACTIVE : GHOST_IDLE}
+                className={popover === "eq" || eqEnabled ? GHOST : GHOST_IDLE}
+                style={popover === "eq" || eqEnabled ? accentActive : undefined}
               >
                 <SlidersHorizontal className="h-[18px] w-[18px]" />
               </HapticButton>

--- a/src/components/music/MusicItemCard.tsx
+++ b/src/components/music/MusicItemCard.tsx
@@ -6,6 +6,7 @@ import { useActiveDownloadForVideo, useIsDownloaded } from '../../lib/useDownloa
 import { downloadAlbum, useCollectionDownloadState } from '../../lib/useCollectionDownloads';
 import { upgradeAvatarUrl, upgradeMusicImageUrl } from '../../lib/thumbnails';
 import { extractDominantColorFromImage, useDominantColor } from '../../lib/useDominantColor';
+import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
 import { useMusicPlayerStore } from '../../store/useMusicPlayerStore';
 import { useAlbumLibraryStore } from '../../store/useAlbumLibraryStore';
 import { useLikesStore } from '../../store/useLikesStore';
@@ -144,11 +145,6 @@ function useSongLike(track: SongItem | null | undefined) {
   };
 
   return { liked, toggle };
-}
-
-function colorBackground(color: { r: number; g: number; b: number } | null): React.CSSProperties {
-  if (!color) return { background: 'color-mix(in srgb, var(--color-chrome-zinc-800) 50%, transparent)' };
-  return { background: `rgba(${color.r}, ${color.g}, ${color.b}, 0.22)` };
 }
 
 function albumSubtitle(item: AlbumItem): string {
@@ -654,13 +650,13 @@ function ListRow({
         resolveColor();
       }}
       onMouseLeave={() => setIsHovered(false)}
-      style={isHighlighted ? colorBackground(activeColor) : undefined}
       className={cx(
-        'group relative flex w-full cursor-pointer items-center gap-4 rounded-lg p-2 transition-colors duration-200 ease-out',
+        `group ${COLOR_WASH_HOST} flex w-full cursor-pointer items-center gap-4 rounded-lg p-2`,
         'outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
         className,
       )}
     >
+      <ColorWash active={isHighlighted} color={activeColor} radius="rounded-lg" spread="row" />
       <div className="relative h-12 w-12 shrink-0">
         <Artwork
           src={item.thumbnail}

--- a/src/components/music/MusicItemCard.tsx
+++ b/src/components/music/MusicItemCard.tsx
@@ -7,6 +7,7 @@ import { downloadAlbum, useCollectionDownloadState } from '../../lib/useCollecti
 import { upgradeAvatarUrl, upgradeMusicImageUrl } from '../../lib/thumbnails';
 import { extractDominantColorFromImage, useDominantColor } from '../../lib/useDominantColor';
 import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
+import { useHoverWashColor } from '../../lib/useHoverWashColor';
 import { useMusicPlayerStore } from '../../store/useMusicPlayerStore';
 import { useAlbumLibraryStore } from '../../store/useAlbumLibraryStore';
 import { useLikesStore } from '../../store/useLikesStore';
@@ -299,6 +300,8 @@ function SquareCard({
   const openAddToAlbum = useAlbumLibraryStore((s) => s.openAddToAlbum);
   const showToast = useUiStore((s) => s.showToast);
   const albumDownload = useCollectionDownloadState(albumBrowseId ?? undefined, "album");
+  const washSrc = useProxiedImageUrl(upgradeMusicImageUrl(thumbnail, 320));
+  const wash = useHoverWashColor(washSrc);
   const menuActions: MusicMenuAction[] = isTrack
     ? [
         {
@@ -380,13 +383,16 @@ function SquareCard({
       onClick={onOpen}
       onKeyDown={onKey(onOpen)}
       onContextMenu={menu.openMenuFromContext}
+      onMouseEnter={wash.onMouseEnter}
+      onMouseLeave={wash.onMouseLeave}
       className={cx(
-        'group relative flex cursor-pointer flex-col gap-3',
+        `group ${COLOR_WASH_HOST} flex cursor-pointer flex-col gap-3`,
         fill ? 'w-full' : 'w-40 md:w-48 lg:w-56',
         'rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
         className,
       )}
     >
+      <ColorWash active={wash.isHovered} color={wash.color} radius="rounded-2xl" bleed={6} />
       <div className="relative w-full aspect-square">
         <Artwork
           src={thumbnail}
@@ -468,19 +474,25 @@ function VideoCard16x9({
   className?: string;
   fill?: boolean;
 }) {
+  const washSrc = useProxiedImageUrl(upgradeMusicImageUrl(thumbnail, 480));
+  const wash = useHoverWashColor(washSrc);
+
   return (
     <div
       role="button"
       tabIndex={0}
       onClick={onOpen ?? onPlay}
       onKeyDown={onKey(onOpen ?? onPlay)}
+      onMouseEnter={wash.onMouseEnter}
+      onMouseLeave={wash.onMouseLeave}
       className={cx(
-        'group flex cursor-pointer flex-col gap-3',
+        `group ${COLOR_WASH_HOST} flex cursor-pointer flex-col gap-3`,
         fill ? 'w-full' : 'w-[260px] md:w-[300px]',
         'rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
         className,
       )}
     >
+      <ColorWash active={wash.isHovered} color={wash.color} radius="rounded-2xl" bleed={6} />
       <div className="relative aspect-video w-full">
         <Artwork
           src={thumbnail}
@@ -523,19 +535,25 @@ function CircleCard({
   className?: string;
   fill?: boolean;
 }) {
+  const washSrc = useProxiedImageUrl(upgradeAvatarUrl(thumbnail));
+  const wash = useHoverWashColor(washSrc);
+
   return (
     <div
       role="button"
       tabIndex={0}
       onClick={onOpen}
       onKeyDown={onKey(onOpen)}
+      onMouseEnter={wash.onMouseEnter}
+      onMouseLeave={wash.onMouseLeave}
       className={cx(
-        'group flex cursor-pointer flex-col items-center gap-3 text-center',
+        `group ${COLOR_WASH_HOST} flex cursor-pointer flex-col items-center gap-3 text-center`,
         fill ? 'w-full' : 'w-32 md:w-40',
         'rounded-2xl outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
         className,
       )}
     >
+      <ColorWash active={wash.isHovered} color={wash.color} radius="rounded-2xl" bleed={6} />
       <div className={cx('aspect-square shrink-0', fill ? 'w-full' : 'w-32 md:w-40')}>
         <Artwork
           src={thumbnail}

--- a/src/components/music/MusicOverlay.tsx
+++ b/src/components/music/MusicOverlay.tsx
@@ -285,7 +285,7 @@ export function MusicOverlay() {
               />
               <div className="absolute inset-x-0 bottom-0 z-20 flex flex-col items-center gap-4 bg-linear-to-t from-chrome-neutral-950/90 via-chrome-neutral-950/50 to-transparent px-6 pb-10 pt-24">
                 <div className="w-full max-w-2xl">
-                  <MusicScrubber size="lg" showTimes countdown />
+                  <MusicScrubber size="lg" showTimes countdown expressive />
                 </div>
                 <div className="flex items-center justify-center gap-8">
                   <HapticButton
@@ -399,7 +399,7 @@ export function MusicOverlay() {
                 </div>
 
                 {/* scrubber row */}
-                <MusicScrubber size="lg" showTimes countdown />
+                <MusicScrubber size="lg" showTimes countdown expressive />
 
                 {/* playback row */}
                 <div className="flex w-full items-center justify-between">

--- a/src/components/music/MusicOverlay.tsx
+++ b/src/components/music/MusicOverlay.tsx
@@ -42,6 +42,9 @@ import { AmbientBackdrop } from "./AmbientBackdrop";
 import { EqPanel } from "./EqPanel";
 import { useLyrics } from "../../lib/lyrics/useLyrics";
 import { useDominantColor } from "../../lib/useDominantColor";
+import { accentForeground, accentSurface } from "../../lib/accentColor";
+import { upgradeMusicImageUrl } from "../../lib/thumbnails";
+import { useProxiedImageUrl } from "../../lib/useProxiedImageUrl";
 
 const TOP_BTN =
   "grid h-10 w-10 place-items-center rounded-full text-chrome-neutral-300 transition-colors duration-200 ease-out hover:bg-surface-container-high hover:text-chrome-neutral-100";
@@ -53,7 +56,6 @@ const META_BTN =
 
 const SIDE = "grid h-11 w-11 place-items-center rounded-full transition-colors duration-200 ease-out";
 const SIDE_IDLE = `${SIDE} text-chrome-neutral-300 hover:bg-surface-container-high hover:text-chrome-neutral-100`;
-const SIDE_ACTIVE = `${SIDE} text-[var(--color-primary)] hover:bg-surface-container-high`;
 
 const LAYOUT_SPRING = { type: "spring" as const, stiffness: 320, damping: 36, mass: 0.9 };
 
@@ -107,7 +109,20 @@ export function MusicOverlay() {
   const [eqOpen, setEqOpen] = useState(false);
   const overlayOpen = currentTrack !== null && viewState !== "dock";
   const lyrics = useLyrics(overlayOpen ? currentTrack : null);
-  const accent = useDominantColor(currentTrack?.thumbnail ?? null);
+  /*
+    Sample the URL the artwork actually renders, not the raw field: YouTube
+    Music hands back protocol-relative and unsized image URLs, and a bare `//`
+    src resolves against the Tauri page origin as http, which `img-src https:`
+    then blocks — the load fails and the accent silently falls back to the
+    theme colour. Going through the same helpers as `MusicArtwork` normalises
+    the URL and reuses its cache entry instead of fetching a second copy.
+  */
+  const accentSrc = useProxiedImageUrl(upgradeMusicImageUrl(currentTrack?.thumbnail));
+  const accent = useDominantColor(accentSrc);
+  const accentActive = {
+    color: accentForeground(accent),
+    backgroundColor: accentSurface(accent),
+  };
   const liked = Boolean(
     currentTrack && likedItems.some((item) => (
       item.kind === "music" && item.id === (currentTrack.videoId ?? currentTrack.id)
@@ -388,7 +403,8 @@ export function MusicOverlay() {
                     onClick={toggleShuffle}
                     aria-label={getString("music_shuffle")}
                     aria-pressed={isShuffle}
-                    className={isShuffle ? SIDE_ACTIVE : SIDE_IDLE}
+                    className={isShuffle ? SIDE : SIDE_IDLE}
+                    style={isShuffle ? accentActive : undefined}
                   >
                     <Shuffle className="h-5 w-5" />
                   </HapticButton>
@@ -431,7 +447,8 @@ export function MusicOverlay() {
                       repeatMode === "one" ? getString("music_repeat_one") : getString("music_repeat")
                     }
                     aria-pressed={repeatMode !== "none"}
-                    className={repeatMode !== "none" ? SIDE_ACTIVE : SIDE_IDLE}
+                    className={repeatMode !== "none" ? SIDE : SIDE_IDLE}
+                    style={repeatMode !== "none" ? accentActive : undefined}
                   >
                     {repeatMode === "one" ? (
                       <Repeat1 className="h-5 w-5" />

--- a/src/components/music/MusicOverlay.tsx
+++ b/src/components/music/MusicOverlay.tsx
@@ -38,13 +38,15 @@ import { MusicArtwork } from "./MusicArtwork";
 import { MusicScrubber } from "./MusicScrubber";
 import { MusicQueuePane } from "./MusicQueuePane";
 import { MusicLyrics } from "./MusicLyrics";
-import { AmbientBackdrop } from "./AmbientBackdrop";
+import { AmbientBackdrop, isMusicBackgroundStyle } from "./AmbientBackdrop";
 import { EqPanel } from "./EqPanel";
 import { useLyrics } from "../../lib/lyrics/useLyrics";
 import { useDominantColor } from "../../lib/useDominantColor";
 import { accentForeground, accentSurface } from "../../lib/accentColor";
 import { upgradeMusicImageUrl } from "../../lib/thumbnails";
 import { useProxiedImageUrl } from "../../lib/useProxiedImageUrl";
+import { usePreference } from "../../lib/usePreference";
+import { SETTINGS } from "../../lib/settings/schema";
 
 const TOP_BTN =
   "grid h-10 w-10 place-items-center rounded-full text-chrome-neutral-300 transition-colors duration-200 ease-out hover:bg-surface-container-high hover:text-chrome-neutral-100";
@@ -119,6 +121,8 @@ export function MusicOverlay() {
   */
   const accentSrc = useProxiedImageUrl(upgradeMusicImageUrl(currentTrack?.thumbnail));
   const accent = useDominantColor(accentSrc);
+  const [backgroundPref] = usePreference(SETTINGS.MUSIC_PLAYER_BACKGROUND);
+  const backgroundStyle = isMusicBackgroundStyle(backgroundPref) ? backgroundPref : "blur_gradient";
   const accentActive = {
     color: accentForeground(accent),
     backgroundColor: accentSurface(accent),
@@ -194,7 +198,7 @@ export function MusicOverlay() {
           transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
           className="fixed inset-x-0 bottom-0 top-8 z-[60] flex flex-col overflow-hidden bg-chrome-neutral-950"
         >
-          <AmbientBackdrop src={currentTrack.thumbnail} accent={accent} />
+          <AmbientBackdrop src={currentTrack.thumbnail} accent={accent} style={backgroundStyle} />
 
           {/* TOP BAR */}
           <div className="absolute top-0 z-20 flex w-full items-center justify-between p-6">

--- a/src/components/music/MusicQueuePane.tsx
+++ b/src/components/music/MusicQueuePane.tsx
@@ -145,7 +145,7 @@ export function MusicQueuePane() {
       </div>
 
       {/* Scroll area */}
-      <div className="hide-scrollbar -mr-1 flex-1 overflow-y-auto pr-1">
+      <div className="hide-scrollbar -mx-1 flex-1 overflow-y-auto px-1">
         {currentTrack && (
           <>
             <p className="mb-1 px-1 text-[10px] font-semibold uppercase tracking-widest text-chrome-neutral-600">

--- a/src/components/music/MusicScrubber.tsx
+++ b/src/components/music/MusicScrubber.tsx
@@ -7,6 +7,7 @@ interface MusicScrubberProps {
   showTimes?: boolean;
   countdown?: boolean;
   className?: string;
+  expressive?: boolean;
 }
 
 export function MusicScrubber({
@@ -15,6 +16,7 @@ export function MusicScrubber({
   showTimes = false,
   countdown = false,
   className = "",
+  expressive = false,
 }: MusicScrubberProps) {
   const progress = useMusicPlayerStore((s) => s.progress);
   const duration = useMusicPlayerStore((s) => s.duration);
@@ -30,6 +32,7 @@ export function MusicScrubber({
       showTimes={showTimes}
       countdown={countdown}
       className={className}
+      expressive={expressive}
     />
   );
 }

--- a/src/components/music/MusicShelf.tsx
+++ b/src/components/music/MusicShelf.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ChevronRight } from 'lucide-react';
 import { getString } from '../../lib/i18n/index';
+import { ShelfScroller } from '../ui/ShelfScroller';
 
 interface MusicShelfProps<T> {
   title: string;
@@ -67,7 +68,7 @@ export function MusicShelf<T>({
       </div>
       )}
 
-      <div className="flex snap-x gap-6 overflow-x-auto hide-scrollbar px-3 -mx-3 pt-3 -mt-2 pb-6">
+      <ShelfScroller className="flex snap-x gap-6 px-3 -mx-3 pt-3 -mt-2 pb-6">
         {loading
           ? Array.from({ length: skeletonCount }).map((_, i) => (
               <ShelfSkeleton key={i} shape={skeletonShape} />
@@ -77,7 +78,7 @@ export function MusicShelf<T>({
                 {renderItem(item, i)}
               </div>
             ))}
-      </div>
+      </ShelfScroller>
     </section>
   );
 }

--- a/src/components/music/MusicShelf.tsx
+++ b/src/components/music/MusicShelf.tsx
@@ -67,7 +67,7 @@ export function MusicShelf<T>({
       </div>
       )}
 
-      <div className="flex snap-x gap-6 overflow-x-auto hide-scrollbar pb-6">
+      <div className="flex snap-x gap-6 overflow-x-auto hide-scrollbar px-3 -mx-3 pt-3 -mt-2 pb-6">
         {loading
           ? Array.from({ length: skeletonCount }).map((_, i) => (
               <ShelfSkeleton key={i} shape={skeletonShape} />

--- a/src/components/music/VolumePopover.tsx
+++ b/src/components/music/VolumePopover.tsx
@@ -3,6 +3,7 @@ import { Volume2, VolumeX } from "lucide-react";
 
 import { useMusicPlayerStore } from "../../store/useMusicPlayerStore";
 import { getString } from "../../lib/i18n/index";
+import { Slider } from "../ui/Slider";
 
 export function VolumePopover({ open }: { open: boolean }) {
   const volume = useMusicPlayerStore((s) => s.volume);
@@ -32,16 +33,14 @@ export function VolumePopover({ open }: { open: boolean }) {
           >
             {shown === 0 ? <VolumeX className="h-5 w-5" /> : <Volume2 className="h-5 w-5" />}
           </button>
-          <input
-            type="range"
+          <Slider
             min={0}
             max={1}
             step={0.01}
             value={shown}
-            onChange={(e) => setVolume(Number(e.target.value))}
+            onChange={setVolume}
             aria-label={getString("music_volume")}
-            style={{ accentColor: "var(--color-primary)" }}
-            className="h-1 flex-1 cursor-pointer"
+            className="flex-1"
           />
           <span className="w-8 shrink-0 text-right font-mono text-xs tabular-nums text-chrome-neutral-400">
             {Math.round(shown * 100)}

--- a/src/components/player/FlowPlayerControls.tsx
+++ b/src/components/player/FlowPlayerControls.tsx
@@ -30,6 +30,7 @@ import { SubtitleCustomizer } from "./SubtitleCustomizer";
 import { SponsorBlockSubmitDialog } from "./SponsorBlockSubmitDialog";
 import { SponsorBlockIcon } from "../ui/SponsorBlockIcon";
 import { getString } from "../../lib/i18n/index";
+import { Slider } from "../ui/Slider";
 import { videoCodecLabel } from "../../lib/settings/playerRuntime";
 
 export interface FlowPlayerControlsProps {
@@ -617,20 +618,20 @@ export const FlowPlayerControls: React.FC<FlowPlayerControlsProps> = ({
                     <Volume2 size={19} />
                   )}
                 </button>
-                <input
-                  aria-label="Volume"
-                  type="range"
-                  min={0}
-                  max={1}
-                  step={0.01}
-                  value={muted ? 0 : volume}
-                  onChange={(event) => {
-                    const value = Number(event.target.value);
-                    setVolume(value);
-                    setMuted(value === 0);
-                  }}
-                  className="h-1 w-0 accent-chrome-white opacity-0 transition-all group-hover/volume:w-20 group-hover/volume:opacity-100"
-                />
+                <div className="w-0 overflow-hidden opacity-0 transition-all group-hover/volume:w-20 group-hover/volume:opacity-100">
+                  <Slider
+                    aria-label="Volume"
+                    min={0}
+                    max={1}
+                    step={0.01}
+                    value={muted ? 0 : volume}
+                    onChange={(value) => {
+                      setVolume(value);
+                      setMuted(value === 0);
+                    }}
+                  />
+                </div>
+
               </div>
 
               <div className="ml-1 flex items-center gap-1.5">

--- a/src/components/playlist/AddToPlaylistModal.tsx
+++ b/src/components/playlist/AddToPlaylistModal.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { ListVideo, Plus, X } from "lucide-react";
 import { getString } from "../../lib/i18n/index";
+import { Button } from "../ui/Button";
 import {
   addVideoToStoredPlaylist,
   createStoredPlaylist,
@@ -196,20 +197,23 @@ export function AddToPlaylistModal() {
               className="w-full rounded-lg border border-chrome-neutral-800 bg-surface-container-low px-3 py-2 text-sm text-chrome-neutral-100 outline-none transition-colors placeholder:text-chrome-neutral-500 focus:border-chrome-neutral-700"
             />
             <div className="flex items-center justify-end gap-2">
-              <button
+              <Button
                 type="button"
                 onClick={() => setCreating(false)}
-                className="rounded-full px-3 py-1.5 text-sm font-medium text-chrome-neutral-300 transition-colors hover:bg-surface-container-high"
+                variant="ghost"
+                size="sm"
+                className="text-sm text-chrome-neutral-300"
               >
                 {getString("cancel")}
-              </button>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 disabled={!newName.trim()}
-                className="rounded-full bg-[var(--color-primary)] px-4 py-1.5 text-sm font-medium text-[var(--color-on-primary)] transition-colors hover:opacity-90 disabled:opacity-50"
+                size="sm"
+                className="px-4 text-sm"
               >
                 {getString("playlist_create")}
-              </button>
+              </Button>
             </div>
           </form>
         ) : (

--- a/src/components/settings/SettingItem.tsx
+++ b/src/components/settings/SettingItem.tsx
@@ -4,6 +4,8 @@ export interface SettingItemProps {
   title: string;
   description?: string;
   disabled?: boolean;
+  /** Optional leading glyph, for lists where the rows need to be scannable. */
+  icon?: ReactNode;
   children: ReactNode;
 }
 
@@ -11,7 +13,7 @@ function cx(...parts: Array<string | false | null | undefined>): string {
   return parts.filter(Boolean).join(' ');
 }
 
-export function SettingItem({ title, description, disabled = false, children }: SettingItemProps) {
+export function SettingItem({ title, description, disabled = false, icon, children }: SettingItemProps) {
   return (
     <div
       aria-disabled={disabled}
@@ -20,6 +22,7 @@ export function SettingItem({ title, description, disabled = false, children }: 
         disabled ? 'opacity-50' : 'hover:bg-surface-container'
       )}
     >
+      {icon && <span className="mr-3 shrink-0 text-chrome-neutral-400">{icon}</span>}
       <div className="flex-1 min-w-0 mr-4">
         <div className="text-sm font-medium text-chrome-neutral-200">{title}</div>
         {description && (

--- a/src/components/settings/tabs/AppearanceTab.tsx
+++ b/src/components/settings/tabs/AppearanceTab.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Plus } from "lucide-react";
 import { CustomThemeEditor } from "../../theme/CustomThemeEditor";
 import { ThemePreview } from "../../theme/ThemePreview";
+import { Button } from "../../ui/Button";
 import { getString } from "../../../lib/i18n/index";
 import {
   BUILTIN_THEMES,
@@ -51,10 +52,10 @@ export function AppearanceTab() {
           <h1 className="text-3xl font-bold tracking-tight text-chrome-neutral-100">{getString("settings_appearance")}</h1>
           <p className="mt-2 text-sm text-chrome-neutral-400">{getString("theme_page_description")}</p>
         </div>
-        <button type="button" onClick={createTheme} disabled={customThemes.length >= 24} className="flex cursor-pointer items-center gap-2 rounded-full bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-on-primary)] transition-colors disabled:cursor-not-allowed disabled:opacity-40">
+        <Button onClick={createTheme} disabled={customThemes.length >= 24}>
           <Plus size={17} />
           {getString("theme_create")}
-        </button>
+        </Button>
       </div>
 
       <section className="mt-8 rounded-2xl border border-chrome-neutral-800 bg-surface-container-low p-5">
@@ -64,9 +65,9 @@ export function AppearanceTab() {
         </div>
         <div className="mt-4 flex flex-wrap gap-2">
           {THEME_VARIANTS.map((item) => (
-            <button key={item} type="button" onClick={() => void setVariant(item)} className={`cursor-pointer rounded-full px-4 py-2 text-sm font-medium transition-colors ${variant === item ? "bg-[var(--color-primary)] text-[var(--color-on-primary)]" : "bg-surface-container-high text-chrome-neutral-300 hover:bg-surface-container-highest"}`}>
+            <Button key={item} variant={variant === item ? "primary" : "secondary"} onClick={() => void setVariant(item)}>
               {getString(`theme_variant_${item}` as Parameters<typeof getString>[0])}
-            </button>
+            </Button>
           ))}
         </div>
       </section>

--- a/src/components/settings/tabs/AppearanceTab.tsx
+++ b/src/components/settings/tabs/AppearanceTab.tsx
@@ -3,6 +3,9 @@ import { Plus } from "lucide-react";
 import { CustomThemeEditor } from "../../theme/CustomThemeEditor";
 import { ThemePreview } from "../../theme/ThemePreview";
 import { Button } from "../../ui/Button";
+import { ToggleSwitch } from "../../ui/ToggleSwitch";
+import { useBoolPref } from "../../../lib/usePreference";
+import { SETTINGS } from "../../../lib/settings/schema";
 import { getString } from "../../../lib/i18n/index";
 import {
   BUILTIN_THEMES,
@@ -22,6 +25,7 @@ export function AppearanceTab() {
     saveCustomThemes,
   } = useTheme();
   const [editingTheme, setEditingTheme] = useState<CustomThemeDefinition | null>(null);
+  const [expressiveSliders, setExpressiveSliders] = useBoolPref(SETTINGS.EXPRESSIVE_SLIDERS_ENABLED, true);
 
   const createTheme = () => {
     const id = `custom-${crypto.randomUUID()}`;
@@ -70,6 +74,14 @@ export function AppearanceTab() {
             </Button>
           ))}
         </div>
+      </section>
+
+      <section className="mt-8 flex items-center justify-between gap-6 rounded-2xl border border-chrome-neutral-800 bg-surface-container-low p-5">
+        <div className="min-w-0">
+          <h2 className="text-base font-medium text-chrome-neutral-200">{getString("settings_expressive_sliders")}</h2>
+          <p className="mt-1 text-sm text-chrome-neutral-400">{getString("settings_expressive_sliders_desc")}</p>
+        </div>
+        <ToggleSwitch checked={expressiveSliders} onChange={setExpressiveSliders} />
       </section>
 
       <section className="mt-8">

--- a/src/components/settings/tabs/PlayerTab.tsx
+++ b/src/components/settings/tabs/PlayerTab.tsx
@@ -28,6 +28,7 @@ export function PlayerTab() {
   const [speedSlider, setSpeedSlider] = useBoolPref(SETTINGS.SPEED_SLIDER_ENABLED, false);
 
   const [doubleTapSeek, setDoubleTapSeek] = useNumberPref(SETTINGS.DOUBLE_TAP_SEEK_SECONDS, 10);
+  const [musicBackground, setMusicBackground] = usePreference(SETTINGS.MUSIC_PLAYER_BACKGROUND);
 
   const [subtitles, setSubtitles] = useBoolPref(SETTINGS.SUBTITLES_ENABLED, false);
   const [subtitleLang, setSubtitleLang] = usePreference(SETTINGS.PREFERRED_SUBTITLE_LANGUAGE, 'en');
@@ -183,6 +184,14 @@ export function PlayerTab() {
         </SettingItem>
         <SettingItem title={getString('settings_adaptive_player')} description={getString('settings_adaptive_player_desc')} disabled={isSettingDisabledUntilWired(SETTINGS.ADAPTIVE_PLAYER_SIZE_ENABLED)}>
           <ToggleSwitch checked={adaptiveSize} onChange={setAdaptiveSize} disabled={isSettingDisabledUntilWired(SETTINGS.ADAPTIVE_PLAYER_SIZE_ENABLED)} />
+        </SettingItem>
+        <SettingItem title={getString('settings_music_player_background')} description={getString('settings_music_player_background_desc')}>
+          <Select value={musicBackground} onChange={setMusicBackground} options={[
+            { value: 'blur_gradient', label: getString('settings_music_player_background_blur_gradient') },
+            { value: 'blur', label: getString('settings_music_player_background_blur') },
+            { value: 'gradient', label: getString('settings_music_player_background_gradient') },
+            { value: 'default', label: getString('settings_music_player_background_default') },
+          ]} />
         </SettingItem>
       </SettingsGroup>
     </div>

--- a/src/components/shelf/PlaylistShelf.tsx
+++ b/src/components/shelf/PlaylistShelf.tsx
@@ -85,7 +85,7 @@ export const PlaylistShelf: React.FC<PlaylistShelfProps> = ({
         {/* Scrollable Container */}
         <div
           ref={scrollRef}
-          className="flex gap-6 overflow-x-auto scroll-smooth scrollbar-none pb-2 pt-2 px-1 -mx-1"
+          className="flex gap-6 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-1 pb-3"
         >
           {playlists.map((playlist) => (
             <div

--- a/src/components/shelf/PlaylistShelf.tsx
+++ b/src/components/shelf/PlaylistShelf.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+import { ShelfScroller } from "../ui/ShelfScroller";
 import { PlaylistCard } from "../video/PlaylistCard";
 import type { PlaylistSummary } from "../../types/video";
 
@@ -14,51 +14,10 @@ export const PlaylistShelf: React.FC<PlaylistShelfProps> = ({
   playlists,
   onPlaylistClick,
 }) => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const checkScrollLimits = () => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setCanScrollLeft(scrollLeft > 2);
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 2);
-  };
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) {
-      checkScrollLimits();
-      el.addEventListener("scroll", checkScrollLimits);
-      window.addEventListener("resize", checkScrollLimits);
-    }
-    
-    const timer = setTimeout(checkScrollLimits, 200);
-    
-    return () => {
-      if (el) {
-        el.removeEventListener("scroll", checkScrollLimits);
-        window.removeEventListener("resize", checkScrollLimits);
-      }
-      clearTimeout(timer);
-    };
-  }, [playlists]);
-
-  const handleScroll = (direction: "left" | "right") => {
-    if (scrollRef.current) {
-      const { scrollLeft, clientWidth } = scrollRef.current;
-      const scrollAmount = direction === "left" ? -clientWidth * 0.75 : clientWidth * 0.75;
-      scrollRef.current.scrollTo({
-        left: scrollLeft + scrollAmount,
-        behavior: "smooth",
-      });
-    }
-  };
-
   if (!playlists || playlists.length === 0) return null;
 
   return (
-    <div className="relative group/shelf flex flex-col gap-4 py-4 border-b border-chrome-zinc-900 last:border-0">
+    <div className="relative flex flex-col gap-4 py-4 border-b border-chrome-zinc-900 last:border-0">
       {/* Shelf Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold text-chrome-zinc-100 tracking-tight flex items-center gap-2">
@@ -69,48 +28,19 @@ export const PlaylistShelf: React.FC<PlaylistShelfProps> = ({
         </h2>
       </div>
 
-      {/* Shelf Slider Area */}
-      <div className="relative w-full overflow-visible">
-        {/* Left Navigation Chevron */}
-        {canScrollLeft && (
-          <button
-            onClick={() => handleScroll("left")}
-            className="absolute left-0 top-1/2 -translate-y-1/2 -ml-2 sm:-ml-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-chrome-black/80 hover:bg-chrome-black border border-chrome-zinc-800 text-chrome-zinc-200 hover:text-chrome-white opacity-0 group-hover/shelf:opacity-100 transition duration-200 ease-out transform active:scale-90 hover:scale-105 pointer-events-auto cursor-pointer"
-            aria-label="Scroll left"
+      <ShelfScroller className="flex gap-6 px-3 -mx-3 pt-3 -mt-1 pb-3">
+        {playlists.map((playlist) => (
+          <div
+            key={playlist.id}
+            className="w-[240px] sm:w-[280px] shrink-0 transform transition-transform duration-300 hover:translate-y-[-2px]"
           >
-            <ChevronLeft size={20} strokeWidth={2.5} />
-          </button>
-        )}
-
-        {/* Scrollable Container */}
-        <div
-          ref={scrollRef}
-          className="flex gap-6 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-1 pb-3"
-        >
-          {playlists.map((playlist) => (
-            <div
-              key={playlist.id}
-              className="w-[240px] sm:w-[280px] shrink-0 transform transition-transform duration-300 hover:translate-y-[-2px]"
-            >
-              <PlaylistCard
-                playlist={playlist}
-                onClick={onPlaylistClick}
-              />
-            </div>
-          ))}
-        </div>
-
-        {/* Right Navigation Chevron */}
-        {canScrollRight && (
-          <button
-            onClick={() => handleScroll("right")}
-            className="absolute right-0 top-1/2 -translate-y-1/2 -mr-2 sm:-mr-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-chrome-black/80 hover:bg-chrome-black border border-chrome-zinc-800 text-chrome-zinc-200 hover:text-chrome-white opacity-0 group-hover/shelf:opacity-100 transition duration-200 ease-out transform active:scale-90 hover:scale-105 pointer-events-auto cursor-pointer"
-            aria-label="Scroll right"
-          >
-            <ChevronRight size={20} strokeWidth={2.5} />
-          </button>
-        )}
-      </div>
+            <PlaylistCard
+              playlist={playlist}
+              onClick={onPlaylistClick}
+            />
+          </div>
+        ))}
+      </ShelfScroller>
     </div>
   );
 };

--- a/src/components/shelf/PostShelf.tsx
+++ b/src/components/shelf/PostShelf.tsx
@@ -83,7 +83,7 @@ export const PostShelf: React.FC<PostShelfProps> = ({
         {/* Scrollable Container */}
         <div
           ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none pb-2 px-1 -mx-1"
+          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-2 pb-3"
         >
           {posts.map((post) => (
             <div

--- a/src/components/shelf/PostShelf.tsx
+++ b/src/components/shelf/PostShelf.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+import { ShelfScroller } from "../ui/ShelfScroller";
 import { PostCard } from "../video/PostCard";
 import type { PostSummary } from "../../types/video";
 
@@ -12,51 +12,10 @@ export const PostShelf: React.FC<PostShelfProps> = ({
   title,
   posts,
 }) => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const checkScrollLimits = () => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setCanScrollLeft(scrollLeft > 2);
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 2);
-  };
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) {
-      checkScrollLimits();
-      el.addEventListener("scroll", checkScrollLimits);
-      window.addEventListener("resize", checkScrollLimits);
-    }
-    
-    const timer = setTimeout(checkScrollLimits, 200);
-    
-    return () => {
-      if (el) {
-        el.removeEventListener("scroll", checkScrollLimits);
-        window.removeEventListener("resize", checkScrollLimits);
-      }
-      clearTimeout(timer);
-    };
-  }, [posts]);
-
-  const handleScroll = (direction: "left" | "right") => {
-    if (scrollRef.current) {
-      const { scrollLeft, clientWidth } = scrollRef.current;
-      const scrollAmount = direction === "left" ? -clientWidth * 0.75 : clientWidth * 0.75;
-      scrollRef.current.scrollTo({
-        left: scrollLeft + scrollAmount,
-        behavior: "smooth",
-      });
-    }
-  };
-
   if (!posts || posts.length === 0) return null;
 
   return (
-    <div className="relative group/shelf flex flex-col gap-4 py-4 border-b border-chrome-zinc-900 last:border-0">
+    <div className="relative flex flex-col gap-4 py-4 border-b border-chrome-zinc-900 last:border-0">
       {/* Shelf Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold text-chrome-zinc-100 tracking-tight flex items-center gap-2">
@@ -67,48 +26,19 @@ export const PostShelf: React.FC<PostShelfProps> = ({
         </h2>
       </div>
 
-      {/* Shelf Slider Area */}
-      <div className="relative w-full overflow-visible">
-        {/* Left Navigation Chevron */}
-        {canScrollLeft && (
-          <button
-            onClick={() => handleScroll("left")}
-            className="absolute left-0 top-[40%] -translate-y-1/2 -ml-2 sm:-ml-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-chrome-black/80 hover:bg-chrome-black border border-chrome-zinc-800 text-chrome-zinc-200 hover:text-chrome-white opacity-0 group-hover/shelf:opacity-100 transition duration-200 ease-out transform active:scale-90 hover:scale-105 pointer-events-auto cursor-pointer"
-            aria-label="Scroll left"
+      <ShelfScroller className="flex gap-4 px-3 -mx-3 pt-3 -mt-2 pb-3">
+        {posts.map((post) => (
+          <div
+            key={post.id}
+            className="w-[320px] sm:w-[480px] shrink-0 transform transition-transform duration-300 hover:translate-y-[-2px] flex"
           >
-            <ChevronLeft size={20} strokeWidth={2.5} />
-          </button>
-        )}
-
-        {/* Scrollable Container */}
-        <div
-          ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-2 pb-3"
-        >
-          {posts.map((post) => (
-            <div
-              key={post.id}
-              className="w-[320px] sm:w-[480px] shrink-0 transform transition-transform duration-300 hover:translate-y-[-2px] flex"
-            >
-              {/* Force clean layout for cards in a row */}
-              <div className="w-full h-full flex flex-col mb-0 select-text">
-                <PostCard post={post} />
-              </div>
+            {/* Force clean layout for cards in a row */}
+            <div className="w-full h-full flex flex-col mb-0 select-text">
+              <PostCard post={post} />
             </div>
-          ))}
-        </div>
-
-        {/* Right Navigation Chevron */}
-        {canScrollRight && (
-          <button
-            onClick={() => handleScroll("right")}
-            className="absolute right-0 top-[40%] -translate-y-1/2 -mr-2 sm:-mr-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-chrome-black/80 hover:bg-chrome-black border border-chrome-zinc-800 text-chrome-zinc-200 hover:text-chrome-white opacity-0 group-hover/shelf:opacity-100 transition duration-200 ease-out transform active:scale-90 hover:scale-105 pointer-events-auto cursor-pointer"
-            aria-label="Scroll right"
-          >
-            <ChevronRight size={20} strokeWidth={2.5} />
-          </button>
-        )}
-      </div>
+          </div>
+        ))}
+      </ShelfScroller>
     </div>
   );
 };

--- a/src/components/shelf/ShortsShelf.tsx
+++ b/src/components/shelf/ShortsShelf.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+import { ShelfScroller } from "../ui/ShelfScroller";
 import type { ShortVideoSummary, VideoSummary } from "../../types/video";
 import { useAppSettingsStore } from "../../store/useAppSettingsStore";
 import { SETTINGS } from "../../lib/settings/schema";
@@ -16,51 +16,10 @@ export const ShortsShelf: React.FC<ShortsShelfProps> = ({
   shorts,
 }) => {
   const shortsShelfEnabled = useAppSettingsStore((state) => state.values[SETTINGS.SHORTS_SHELF_ENABLED] !== "false");
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const checkScrollLimits = () => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setCanScrollLeft(scrollLeft > 2);
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 2);
-  };
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) {
-      checkScrollLimits();
-      el.addEventListener("scroll", checkScrollLimits);
-      window.addEventListener("resize", checkScrollLimits);
-    }
-    
-    const timer = setTimeout(checkScrollLimits, 200);
-    
-    return () => {
-      if (el) {
-        el.removeEventListener("scroll", checkScrollLimits);
-        window.removeEventListener("resize", checkScrollLimits);
-      }
-      clearTimeout(timer);
-    };
-  }, [shorts]);
-
-  const handleScroll = (direction: "left" | "right") => {
-    if (scrollRef.current) {
-      const { scrollLeft, clientWidth } = scrollRef.current;
-      const scrollAmount = direction === "left" ? -clientWidth * 0.75 : clientWidth * 0.75;
-      scrollRef.current.scrollTo({
-        left: scrollLeft + scrollAmount,
-        behavior: "smooth",
-      });
-    }
-  };
-
   if (!shortsShelfEnabled || !shorts || shorts.length === 0) return null;
 
   return (
-    <div className="relative group/shelf flex flex-col gap-4 py-4 border-b border-chrome-zinc-900 last:border-0">
+    <div className="relative flex flex-col gap-4 py-4 border-b border-chrome-zinc-900 last:border-0">
       {/* Shelf Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-bold text-chrome-zinc-100 tracking-tight flex items-center gap-2">
@@ -71,45 +30,16 @@ export const ShortsShelf: React.FC<ShortsShelfProps> = ({
         </h2>
       </div>
 
-      {/* Shelf Slider Area */}
-      <div className="relative w-full overflow-visible">
-        {/* Left Navigation Chevron */}
-        {canScrollLeft && (
-          <button
-            onClick={() => handleScroll("left")}
-            className="absolute left-0 top-1/2 -translate-y-1/2 -ml-2 sm:-ml-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-chrome-black/80 hover:bg-chrome-black border border-chrome-zinc-800 text-chrome-zinc-200 hover:text-chrome-white opacity-0 group-hover/shelf:opacity-100 transition duration-200 ease-out transform active:scale-90 hover:scale-105 pointer-events-auto cursor-pointer"
-            aria-label="Scroll left"
-          >
-            <ChevronLeft size={20} strokeWidth={2.5} />
-          </button>
-        )}
-
-        {/* Scrollable Container */}
-        <div
-          ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-2 pb-3"
-        >
-          {shorts.map((short) => (
-            <ShortCard
-              key={short.id}
-              short={short}
-              queue={shorts}
-              variant="shelf"
-            />
-          ))}
-        </div>
-
-        {/* Right Navigation Chevron */}
-        {canScrollRight && (
-          <button
-            onClick={() => handleScroll("right")}
-            className="absolute right-0 top-1/2 -translate-y-1/2 -mr-2 sm:-mr-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-chrome-black/80 hover:bg-chrome-black border border-chrome-zinc-800 text-chrome-zinc-200 hover:text-chrome-white opacity-0 group-hover/shelf:opacity-100 transition duration-200 ease-out transform active:scale-90 hover:scale-105 pointer-events-auto cursor-pointer"
-            aria-label="Scroll right"
-          >
-            <ChevronRight size={20} strokeWidth={2.5} />
-          </button>
-        )}
-      </div>
+      <ShelfScroller className="flex gap-4 px-3 -mx-3 pt-3 -mt-2 pb-3">
+        {shorts.map((short) => (
+          <ShortCard
+            key={short.id}
+            short={short}
+            queue={shorts}
+            variant="shelf"
+          />
+        ))}
+      </ShelfScroller>
     </div>
   );
 };

--- a/src/components/shelf/ShortsShelf.tsx
+++ b/src/components/shelf/ShortsShelf.tsx
@@ -87,7 +87,7 @@ export const ShortsShelf: React.FC<ShortsShelfProps> = ({
         {/* Scrollable Container */}
         <div
           ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none pb-2 px-1 -mx-1"
+          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-2 pb-3"
         >
           {shorts.map((short) => (
             <ShortCard

--- a/src/components/shelf/VideoShelf.tsx
+++ b/src/components/shelf/VideoShelf.tsx
@@ -101,7 +101,7 @@ export const VideoShelf: React.FC<VideoShelfProps> = ({
         {/* Scrollable Container */}
         <div
           ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none pb-2 px-1 -mx-1 snap-x"
+          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-2 pb-3 snap-x"
         >
           {videos.map((video, index) => (
             <div

--- a/src/components/shelf/VideoShelf.tsx
+++ b/src/components/shelf/VideoShelf.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState, useEffect } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import React from "react";
+import { ShelfScroller } from "../ui/ShelfScroller";
 import { VideoCard } from "../video/VideoCard";
 import type { VideoSummary } from "../../types/video";
 
@@ -26,53 +26,10 @@ export const VideoShelf: React.FC<VideoShelfProps> = ({
   variant = "default",
   hideChannelAvatar = true,
 }) => {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const checkScrollLimits = () => {
-    if (!scrollRef.current) return;
-    const { scrollLeft, scrollWidth, clientWidth } = scrollRef.current;
-    setCanScrollLeft(scrollLeft > 2);
-    // Give a tiny tolerance of 2px for rounding errors
-    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 2);
-  };
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (el) {
-      checkScrollLimits();
-      el.addEventListener("scroll", checkScrollLimits);
-      window.addEventListener("resize", checkScrollLimits);
-    }
-    
-    // Check again after a brief timeout to let images/content render
-    const timer = setTimeout(checkScrollLimits, 200);
-    
-    return () => {
-      if (el) {
-        el.removeEventListener("scroll", checkScrollLimits);
-        window.removeEventListener("resize", checkScrollLimits);
-      }
-      clearTimeout(timer);
-    };
-  }, [videos]);
-
-  const handleScroll = (direction: "left" | "right") => {
-    if (scrollRef.current) {
-      const { scrollLeft, clientWidth } = scrollRef.current;
-      const scrollAmount = direction === "left" ? -clientWidth * 0.75 : clientWidth * 0.75;
-      scrollRef.current.scrollTo({
-        left: scrollLeft + scrollAmount,
-        behavior: "smooth",
-      });
-    }
-  };
-
   if (!videos || videos.length === 0) return null;
 
   return (
-    <div className="relative group/shelf flex flex-col gap-4">
+    <div className="relative flex flex-col gap-4">
       {/* Shelf Header */}
       {title ? (
         <div className="flex items-center justify-between">
@@ -85,53 +42,24 @@ export const VideoShelf: React.FC<VideoShelfProps> = ({
         </div>
       ) : null}
 
-      {/* Shelf Slider Area */}
-      <div className="relative w-full overflow-visible">
-        {/* Left Navigation Chevron */}
-        {canScrollLeft && (
-          <button
-            onClick={() => handleScroll("left")}
-            className="absolute left-0 top-1/2 -translate-y-1/2 -ml-2 sm:-ml-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-surface-container-high hover:bg-surface-container-highest border border-chrome-neutral-800 text-chrome-neutral-300 hover:text-chrome-neutral-100 opacity-0 group-hover/shelf:opacity-100 transition-colors duration-200 ease-out pointer-events-auto cursor-pointer"
-            aria-label="Scroll left"
+      <ShelfScroller className="flex gap-4 px-3 -mx-3 pt-3 -mt-2 pb-3 snap-x">
+        {videos.map((video, index) => (
+          <div
+            key={getVideoKey ? getVideoKey(video, index) : `${video.id}-${index}`}
+            className="w-[280px] sm:w-[320px] shrink-0 transform transition-transform duration-300 hover:translate-y-[-2px]"
           >
-            <ChevronLeft size={20} strokeWidth={2.5} />
-          </button>
-        )}
-
-        {/* Scrollable Container */}
-        <div
-          ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scroll-smooth scrollbar-none px-3 -mx-3 pt-3 -mt-2 pb-3 snap-x"
-        >
-          {videos.map((video, index) => (
-            <div
-              key={getVideoKey ? getVideoKey(video, index) : `${video.id}-${index}`}
-              className="w-[280px] sm:w-[320px] shrink-0 transform transition-transform duration-300 hover:translate-y-[-2px]"
-            >
-              <VideoCard
-                video={video}
-                onPlay={onPlay}
-                onAddToQueue={onAddToQueue}
-                onRemoveFromHistory={onRemoveFromHistory}
-                onRemoveFromContinueWatching={onRemoveFromContinueWatching}
-                variant={variant}
-                hideChannelAvatar={hideChannelAvatar}
-              />
-            </div>
-          ))}
-        </div>
-
-        {/* Right Navigation Chevron */}
-        {canScrollRight && (
-          <button
-            onClick={() => handleScroll("right")}
-            className="absolute right-0 top-1/2 -translate-y-1/2 -mr-2 sm:-mr-4 z-20 flex items-center justify-center w-10 h-10 rounded-full bg-surface-container-high hover:bg-surface-container-highest border border-chrome-neutral-800 text-chrome-neutral-300 hover:text-chrome-neutral-100 opacity-0 group-hover/shelf:opacity-100 transition-colors duration-200 ease-out pointer-events-auto cursor-pointer"
-            aria-label="Scroll right"
-          >
-            <ChevronRight size={20} strokeWidth={2.5} />
-          </button>
-        )}
-      </div>
+            <VideoCard
+              video={video}
+              onPlay={onPlay}
+              onAddToQueue={onAddToQueue}
+              onRemoveFromHistory={onRemoveFromHistory}
+              onRemoveFromContinueWatching={onRemoveFromContinueWatching}
+              variant={variant}
+              hideChannelAvatar={hideChannelAvatar}
+            />
+          </div>
+        ))}
+      </ShelfScroller>
     </div>
   );
 };

--- a/src/components/subscriptions/ChannelSwiper.tsx
+++ b/src/components/subscriptions/ChannelSwiper.tsx
@@ -1,5 +1,6 @@
 import type { SubscribedChannel } from '../../store/useSubscriptionStore';
 import { QuickAccessAvatar } from './QuickAccessAvatar';
+import { ShelfScroller } from '../ui/ShelfScroller';
 
 export interface ChannelSwiperProps {
   channels: SubscribedChannel[];
@@ -15,7 +16,7 @@ export function ChannelSwiper({
   onSelectChannel,
 }: ChannelSwiperProps) {
   return (
-    <div className="flex flex-row gap-4 overflow-x-auto py-4 snap-x hide-scrollbar">
+    <ShelfScroller className="flex flex-row gap-4 py-4 snap-x">
       {channels.map((channel) => (
         <QuickAccessAvatar
           key={channel.id}
@@ -26,6 +27,6 @@ export function ChannelSwiper({
           onClick={() => onSelectChannel?.(channel)}
         />
       ))}
-    </div>
+    </ShelfScroller>
   );
 }

--- a/src/components/theme/CustomThemeEditor.tsx
+++ b/src/components/theme/CustomThemeEditor.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { X } from "lucide-react";
 import { getString } from "../../lib/i18n/index";
+import { Button } from "../ui/Button";
 import {
   THEME_VARIANTS,
   type CustomThemeDefinition,
@@ -71,9 +72,9 @@ export function CustomThemeEditor({ theme, onCancel, onSave }: CustomThemeEditor
 
           <div className="mt-6 flex gap-2" role="tablist" aria-label={getString("theme_variant") }>
             {THEME_VARIANTS.map((item) => (
-              <button key={item} type="button" role="tab" aria-selected={variant === item} onClick={() => setVariant(item)} className={`cursor-pointer rounded-full px-4 py-2 text-sm font-medium transition-colors ${variant === item ? "bg-[var(--color-primary)] text-[var(--color-on-primary)]" : "bg-surface-container-high text-chrome-neutral-300 hover:bg-surface-container-highest"}`}>
+              <Button key={item} role="tab" aria-selected={variant === item} variant={variant === item ? "primary" : "secondary"} onClick={() => setVariant(item)}>
                 {getString(`theme_variant_${item}` as Parameters<typeof getString>[0])}
-              </button>
+              </Button>
             ))}
           </div>
 
@@ -93,8 +94,8 @@ export function CustomThemeEditor({ theme, onCancel, onSave }: CustomThemeEditor
         </div>
 
         <footer className="flex justify-end gap-2 border-t border-chrome-neutral-800 px-6 py-4">
-          <button type="button" onClick={onCancel} className="cursor-pointer rounded-full bg-surface-container-high px-4 py-2 text-sm font-medium text-chrome-neutral-200 transition-colors hover:bg-surface-container-highest">{getString("theme_cancel")}</button>
-          <button type="button" disabled={!draft.name.trim()} onClick={() => onSave({ ...draft, name: draft.name.trim() })} className="cursor-pointer rounded-full bg-[var(--color-primary)] px-4 py-2 text-sm font-medium text-[var(--color-on-primary)] transition-colors disabled:cursor-not-allowed disabled:opacity-40">{getString("theme_save")}</button>
+          <Button variant="secondary" onClick={onCancel}>{getString("theme_cancel")}</Button>
+          <Button disabled={!draft.name.trim()} onClick={() => onSave({ ...draft, name: draft.name.trim() })}>{getString("theme_save")}</Button>
         </footer>
       </div>
     </div>

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,20 +1,28 @@
-import { ButtonHTMLAttributes } from 'react';
+import { motion, type HTMLMotionProps } from 'framer-motion';
 
-export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+/*
+  The same press feedback the player's transport buttons use, so a click feels
+  identical wherever it happens. Deliberately just the tap squash — no shape
+  morph, no spring-back overshoot.
+*/
+const PRESS = { scale: 0.9 };
+const PRESS_SPRING = { type: 'spring' as const, stiffness: 400, damping: 17 };
+
+export interface ButtonProps extends Omit<HTMLMotionProps<'button'>, 'ref'> {
   variant?: 'primary' | 'secondary' | 'tonal' | 'outline' | 'ghost' | 'destructive';
   size?: 'sm' | 'md' | 'lg';
 }
 
-export function Button({ 
-  children, 
-  variant = 'primary', 
-  size = 'md', 
-  className = '', 
-  disabled, 
-  ...props 
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  disabled,
+  ...props
 }: ButtonProps) {
   const baseStyles = 'inline-flex items-center justify-center gap-2 rounded-full font-medium transition-colors duration-200 ease-out focus:outline-none disabled:opacity-50 disabled:pointer-events-none';
-  
+
   const variants = {
     primary: 'bg-[var(--color-primary)] text-[var(--color-on-primary)] hover:opacity-90',
     secondary: 'bg-surface-container-high text-chrome-neutral-200 hover:bg-surface-container-highest',
@@ -31,12 +39,14 @@ export function Button({
   };
 
   return (
-    <button 
+    <motion.button
       className={`${baseStyles} ${variants[variant]} ${sizes[size]} ${className}`}
       disabled={disabled}
+      whileTap={disabled ? undefined : PRESS}
+      transition={PRESS_SPRING}
       {...props}
     >
       {children}
-    </button>
+    </motion.button>
   );
 }

--- a/src/components/ui/ColorWash.tsx
+++ b/src/components/ui/ColorWash.tsx
@@ -1,0 +1,60 @@
+import type { CSSProperties } from 'react';
+import { IS_LINUX_RUNTIME } from '../../lib/platform';
+import type { Rgb } from '../../lib/useDominantColor';
+
+/**
+ * Hosts must own a stacking context, otherwise the wash paints over the card's
+ * own content instead of behind it.
+ */
+export const COLOR_WASH_HOST = 'relative isolate';
+
+const NEUTRAL_WASH = 'color-mix(in srgb, var(--color-chrome-zinc-800) 50%, transparent)';
+
+/*
+  Collapsed narrower on X than on Y, so the wash reads as spreading out towards
+  the sides. Rows collapse far less: their travel is the same fraction of a much
+  wider box, and the overshoot below scales with it.
+*/
+const COLLAPSED_TRANSFORM: Record<ColorWashSpread, string> = {
+  card: 'scale(0.68, 0.86)',
+  row: 'scale(0.9, 0.86)',
+};
+const EXPANDED_TRANSFORM = 'scale(1, 1)';
+
+/*
+  The entry curve overshoots by 3.8% of the travelled distance, so the wash
+  settles into its host's edge instead of stopping dead against it. That peak
+  stays within the bleed the grid and the shelves reserve around every card.
+*/
+const EXPAND = 'transform 420ms cubic-bezier(0.34, 1.34, 0.5, 1), opacity 220ms cubic-bezier(0.33, 1, 0.68, 1)';
+const COLLAPSE = 'transform 220ms cubic-bezier(0.4, 0, 0.2, 1), opacity 180ms ease-out';
+// WebKitGTK composites on the CPU, where scaling a card-sized layer under a
+// sweeping cursor costs what the thumbnail zoom already costs us on Linux.
+const LINUX_FADE = 'opacity 200ms ease-out';
+
+export type ColorWashSpread = 'card' | 'row';
+
+export interface ColorWashProps {
+  /** Drives both the fade and the expansion. */
+  active: boolean;
+  /** Extracted artwork colour; falls back to a neutral tint when unresolved. */
+  color?: Rgb | null;
+  /** Must mirror the host's corner radius. */
+  radius?: string;
+  alpha?: number;
+  /** How far the wash collapses at rest — `row` for wide, short hosts. */
+  spread?: ColorWashSpread;
+}
+
+/** Artwork-tinted hover layer that expands from the centre of its host. */
+export function ColorWash({ active, color, radius = 'rounded-xl', alpha = 0.22, spread = 'card' }: ColorWashProps) {
+  const style: CSSProperties = {
+    zIndex: -1,
+    background: color ? `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})` : NEUTRAL_WASH,
+    opacity: active ? 1 : 0,
+    transform: IS_LINUX_RUNTIME || active ? EXPANDED_TRANSFORM : COLLAPSED_TRANSFORM[spread],
+    transition: IS_LINUX_RUNTIME ? LINUX_FADE : active ? EXPAND : COLLAPSE,
+  };
+
+  return <span aria-hidden className={`color-wash pointer-events-none absolute inset-0 ${radius}`} style={style} />;
+}

--- a/src/components/ui/ColorWash.tsx
+++ b/src/components/ui/ColorWash.tsx
@@ -44,11 +44,27 @@ export interface ColorWashProps {
   alpha?: number;
   /** How far the wash collapses at rest — `row` for wide, short hosts. */
   spread?: ColorWashSpread;
+  /**
+   * Pixels the wash extends past the host on every side, for a halo around a
+   * card that owns its own width. Padding plus a negative margin cannot do this
+   * on a host with an explicit width: a fixed width simply shrinks by the
+   * padding, and `w-full` over-constrains the box so the right margin is
+   * dropped and the card slides sideways.
+   */
+  bleed?: number;
 }
 
 /** Artwork-tinted hover layer that expands from the centre of its host. */
-export function ColorWash({ active, color, radius = 'rounded-xl', alpha = 0.22, spread = 'card' }: ColorWashProps) {
+export function ColorWash({
+  active,
+  color,
+  radius = 'rounded-xl',
+  alpha = 0.22,
+  spread = 'card',
+  bleed = 0,
+}: ColorWashProps) {
   const style: CSSProperties = {
+    inset: bleed ? `-${bleed}px` : 0,
     zIndex: -1,
     background: color ? `rgba(${color.r}, ${color.g}, ${color.b}, ${alpha})` : NEUTRAL_WASH,
     opacity: active ? 1 : 0,
@@ -56,5 +72,5 @@ export function ColorWash({ active, color, radius = 'rounded-xl', alpha = 0.22, 
     transition: IS_LINUX_RUNTIME ? LINUX_FADE : active ? EXPAND : COLLAPSE,
   };
 
-  return <span aria-hidden className={`color-wash pointer-events-none absolute inset-0 ${radius}`} style={style} />;
+  return <span aria-hidden className={`color-wash pointer-events-none absolute ${radius}`} style={style} />;
 }

--- a/src/components/ui/MediaScrubber.tsx
+++ b/src/components/ui/MediaScrubber.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useRef, useState, type CSSProperties } from "react";
 import type React from "react";
 
 import { getString } from "../../lib/i18n/index";
 import { formatTime } from "../../lib/musicFormat";
+import { useExpressiveSliders } from "../../lib/useExpressiveSliders";
 
 interface MediaScrubberProps {
   progress: number;
@@ -14,6 +15,8 @@ interface MediaScrubberProps {
   countdown?: boolean;
   ariaLabel?: string;
   className?: string;
+  /** Opt in to the Material 3 Expressive look; ignored when the user turns it off. */
+  expressive?: boolean;
 }
 
 export function MediaScrubber({
@@ -26,7 +29,10 @@ export function MediaScrubber({
   countdown = false,
   ariaLabel = getString("music_seek"),
   className = "",
+  expressive = false,
 }: MediaScrubberProps) {
+  const expressiveEnabled = useExpressiveSliders();
+  const isExpressive = expressive && expressiveEnabled;
   const trackRef = useRef<HTMLDivElement | null>(null);
   const [dragging, setDragging] = useState(false);
   const [dragRatio, setDragRatio] = useState(0);
@@ -96,20 +102,36 @@ export function MediaScrubber({
     ? "bottom-[3px] translate-y-1/2"
     : "top-1/2 -translate-y-1/2";
 
-  const bar = (
+  const sliderProps = {
+    ref: trackRef,
+    role: "slider" as const,
+    tabIndex: 0,
+    "aria-label": ariaLabel,
+    "aria-valuemin": 0,
+    "aria-valuemax": Math.round(duration),
+    "aria-valuenow": Math.round(ratio * duration),
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: endDrag,
+    onPointerCancel: endDrag,
+    onKeyDown,
+  };
+
+  const bar = isExpressive ? (
     <div
-      ref={trackRef}
-      role="slider"
-      tabIndex={0}
-      aria-label={ariaLabel}
-      aria-valuemin={0}
-      aria-valuemax={Math.round(duration)}
-      aria-valuenow={Math.round(ratio * duration)}
-      onPointerDown={onPointerDown}
-      onPointerMove={onPointerMove}
-      onPointerUp={endDrag}
-      onPointerCancel={endDrag}
-      onKeyDown={onKeyDown}
+      {...sliderProps}
+      className="m3-slider flex-1 cursor-pointer outline-none"
+      data-pressed={dragging}
+      style={{ "--m3-fill": ratio } as CSSProperties}
+    >
+      <span className="m3-slider__track m3-slider__track--active" />
+      <span className="m3-slider__track m3-slider__track--inactive" />
+      {ratio < 0.97 && <span className="m3-slider__stop" />}
+      <span className="m3-slider__handle" />
+    </div>
+  ) : (
+    <div
+      {...sliderProps}
       className={`group/scrub relative flex ${hitH} flex-1 cursor-pointer touch-none outline-none`}
     >
       <div className={`relative ${trackH} w-full overflow-hidden ${trackShape}`}>

--- a/src/components/ui/ShelfScroller.tsx
+++ b/src/components/ui/ShelfScroller.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { getString } from '../../lib/i18n/index';
+
+const NAV_BUTTON =
+  'absolute top-1/2 z-20 grid h-10 w-10 -translate-y-1/2 cursor-pointer place-items-center rounded-full border border-chrome-neutral-800 bg-surface-container-high text-chrome-neutral-300 opacity-0 transition-colors duration-200 ease-out hover:bg-surface-container-highest hover:text-chrome-neutral-100 group-hover/shelfnav:opacity-100';
+
+export interface ShelfScrollerProps {
+  children: ReactNode;
+  /** Classes for the scrolling element itself — gap, padding, snap, grid flow. */
+  className?: string;
+}
+
+/**
+ * Horizontal shelf with the scroll-position-aware arrows, so every shelf in the
+ * app navigates the same way instead of each one re-deriving the limits.
+ */
+export function ShelfScroller({ children, className = '' }: ShelfScrollerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const measure = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    const { scrollLeft, scrollWidth, clientWidth } = element;
+    setCanScrollLeft(scrollLeft > 2);
+    // 2px of slack so sub-pixel rounding cannot strand the right-hand arrow.
+    setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 2);
+  }, []);
+
+  // No dependency list: re-measuring after every render is what keeps the arrows
+  // right when items are added or removed.
+  useLayoutEffect(measure);
+
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+
+    element.addEventListener('scroll', measure, { passive: true });
+    window.addEventListener('resize', measure);
+    // Thumbnails land after mount and change scrollWidth without a re-render.
+    const settle = window.setTimeout(measure, 200);
+
+    return () => {
+      element.removeEventListener('scroll', measure);
+      window.removeEventListener('resize', measure);
+      window.clearTimeout(settle);
+    };
+  }, [measure]);
+
+  const scrollByPage = (direction: -1 | 1) => {
+    const element = scrollRef.current;
+    if (!element) return;
+    element.scrollTo({
+      left: element.scrollLeft + direction * element.clientWidth * 0.75,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <div className="group/shelfnav relative w-full overflow-visible">
+      {canScrollLeft && (
+        <button
+          type="button"
+          onClick={() => scrollByPage(-1)}
+          aria-label={getString('shelf_scroll_left')}
+          className={`${NAV_BUTTON} left-0 -ml-2 sm:-ml-4`}
+        >
+          <ChevronLeft size={20} strokeWidth={2.5} />
+        </button>
+      )}
+
+      <div ref={scrollRef} className={`overflow-x-auto scroll-smooth scrollbar-none ${className}`}>
+        {children}
+      </div>
+
+      {canScrollRight && (
+        <button
+          type="button"
+          onClick={() => scrollByPage(1)}
+          aria-label={getString('shelf_scroll_right')}
+          className={`${NAV_BUTTON} right-0 -mr-2 sm:-mr-4`}
+        >
+          <ChevronRight size={20} strokeWidth={2.5} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -1,0 +1,73 @@
+import { useState, type CSSProperties } from 'react';
+import { useExpressiveSliders } from '../../lib/useExpressiveSliders';
+
+export interface SliderProps {
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (value: number) => void;
+  'aria-label': string;
+  disabled?: boolean;
+  className?: string;
+  orientation?: 'horizontal' | 'vertical';
+}
+
+/**
+ * Material 3 Expressive slider: thick track, thin handle, gap between them.
+ * Falls back to the plain native control when the Settings toggle is off.
+ */
+export function Slider({
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  disabled,
+  className = '',
+  orientation = 'horizontal',
+  'aria-label': ariaLabel,
+}: SliderProps) {
+  const [pressed, setPressed] = useState(false);
+  const expressive = useExpressiveSliders();
+  const vertical = orientation === 'vertical';
+
+  const range = max - min;
+  const fill = range > 0 ? Math.min(1, Math.max(0, (value - min) / range)) : 0;
+
+  const input = (
+    <input
+      className={expressive ? 'm3-slider__input' : `m3-slider-legacy ${vertical ? 'm3-slider-legacy--vertical' : ''} ${className}`}
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      disabled={disabled}
+      aria-label={ariaLabel}
+      onChange={(event) => onChange(Number(event.target.value))}
+      onPointerDown={() => setPressed(true)}
+      onPointerUp={() => setPressed(false)}
+      onPointerCancel={() => setPressed(false)}
+      onBlur={() => setPressed(false)}
+    />
+  );
+
+  if (!expressive) return input;
+
+  return (
+    <div
+      className={`m3-slider ${vertical ? 'm3-slider--vertical' : ''} ${className}`}
+      data-pressed={pressed && !disabled}
+      data-disabled={Boolean(disabled)}
+      style={{ '--m3-fill': fill } as CSSProperties}
+    >
+      <span className="m3-slider__track m3-slider__track--active" />
+      <span className="m3-slider__track m3-slider__track--inactive" />
+      {/* Once the handle covers the end of travel the stop indicator is noise. */}
+      {fill < 0.97 && <span className="m3-slider__stop" />}
+      <span className="m3-slider__handle" />
+      {input}
+    </div>
+  );
+}

--- a/src/components/ui/ToggleSwitch.tsx
+++ b/src/components/ui/ToggleSwitch.tsx
@@ -1,3 +1,25 @@
+import { useState } from 'react';
+import { motion, useReducedMotion } from 'framer-motion';
+import { Check, X } from 'lucide-react';
+
+/*
+  Material 3 Expressive switch. The track is 52x32 with a 24px handle, and the
+  handle swells to 28px while pressed — the size change is the press feedback,
+  so there is no separate hover/active fill.
+*/
+const TRACK_INSET = 2;
+const HANDLE = 24;
+const TRAVEL = 52 - 2 * (TRACK_INSET + 2) - HANDLE;
+const PRESSED_SCALE = 28 / HANDLE;
+
+/*
+  M3's "fast spatial" spring: stiffness 1400 at a 0.9 damping ratio. Framer takes
+  absolute damping, so 0.9 x 2 x sqrt(1400) lands at ~67 — quick, with the small
+  overshoot that gives the expressive switch its snap.
+*/
+const SPRING = { type: 'spring' as const, stiffness: 1400, damping: 67, mass: 1 };
+const REDUCED = { duration: 0.12, ease: 'easeOut' as const };
+
 export interface ToggleSwitchProps {
   checked: boolean;
   onChange: (checked: boolean) => void;
@@ -5,6 +27,9 @@ export interface ToggleSwitchProps {
 }
 
 export function ToggleSwitch({ checked, onChange, disabled }: ToggleSwitchProps) {
+  const [pressed, setPressed] = useState(false);
+  const reduceMotion = useReducedMotion();
+
   return (
     <button
       type="button"
@@ -12,15 +37,37 @@ export function ToggleSwitch({ checked, onChange, disabled }: ToggleSwitchProps)
       aria-checked={checked}
       disabled={disabled}
       onClick={() => onChange(!checked)}
-      className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-200 ease-out cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed ${
-        checked ? 'bg-[var(--color-primary)]' : 'bg-chrome-neutral-700'
+      onPointerDown={() => setPressed(true)}
+      onPointerUp={() => setPressed(false)}
+      onPointerLeave={() => setPressed(false)}
+      onBlur={() => setPressed(false)}
+      className={`relative inline-flex h-8 w-[52px] shrink-0 cursor-pointer items-center rounded-full border-2 px-[2px] transition-colors duration-200 ease-out disabled:cursor-not-allowed disabled:opacity-50 ${
+        checked
+          ? 'border-transparent bg-[var(--color-primary)]'
+          : 'border-chrome-neutral-600 bg-chrome-neutral-800'
       }`}
     >
-      <span
-        className={`inline-block h-4 w-4 rounded-full bg-on-primary transition-transform duration-200 ease-out ${
-          checked ? 'translate-x-6' : 'translate-x-1'
+      <motion.span
+        className={`grid h-6 w-6 place-items-center rounded-full ${
+          checked ? 'bg-on-primary' : 'bg-chrome-neutral-400'
         }`}
-      />
+        animate={{ x: checked ? TRAVEL : 0, scale: pressed && !disabled ? PRESSED_SCALE : 1 }}
+        transition={reduceMotion ? REDUCED : SPRING}
+      >
+        {/* Both icons stay mounted and cross-fade, so neither can pop in late. */}
+        <Check
+          className={`col-start-1 row-start-1 h-4 w-4 text-[var(--color-primary)] transition-all duration-150 ease-out ${
+            checked ? 'scale-100 opacity-100' : 'scale-50 opacity-0'
+          }`}
+          strokeWidth={3}
+        />
+        <X
+          className={`col-start-1 row-start-1 h-4 w-4 text-chrome-neutral-800 transition-all duration-150 ease-out ${
+            checked ? 'scale-50 opacity-0' : 'scale-100 opacity-100'
+          }`}
+          strokeWidth={3}
+        />
+      </motion.span>
     </button>
   );
 }

--- a/src/components/video/PlaylistCard.tsx
+++ b/src/components/video/PlaylistCard.tsx
@@ -12,6 +12,8 @@ import {
 import { downloadPlaylist } from '../../lib/useCollectionDownloads';
 import { useUiStore } from '../../store/useUiStore';
 import { AnchoredPortalMenu, type MenuAnchor } from '../ui/AnchoredPortalMenu';
+import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
+import { useHoverWashColor } from '../../lib/useHoverWashColor';
 
 interface PlaylistCardProps {
   playlist: PlaylistSummary & {
@@ -105,6 +107,7 @@ export function PlaylistCard({
   const [isSaved, setIsSaved] = useState(Boolean(isInLibrary));
   const cardRef = useRef<HTMLDivElement>(null);
   const showToast = useUiStore((state) => state.showToast);
+  const wash = useHoverWashColor(playlist.thumbnailUrl);
   const isProtected = Boolean(playlist.isProtected) || isProtectedPlaylistId(playlist.id);
 
   const resolvedVideoCount = typeof playlist.videoCount === 'number' && playlist.videoCount > 0
@@ -267,7 +270,9 @@ export function PlaylistCard({
   return (
     <div
       ref={cardRef}
-      className="group relative flex cursor-pointer flex-col gap-3"
+      className={`group ${COLOR_WASH_HOST} flex cursor-pointer flex-col gap-3`}
+      onMouseEnter={wash.onMouseEnter}
+      onMouseLeave={wash.onMouseLeave}
       onClick={() => {
         if (onClick) {
           onClick(playlist);
@@ -277,6 +282,8 @@ export function PlaylistCard({
       }}
       onContextMenu={handleContextMenu}
     >
+      <ColorWash active={wash.isHovered} color={wash.color} alpha={0.2} bleed={6} />
+
       <StackedPlaylistThumbnail
         thumbnailUrl={playlist.thumbnailUrl}
         title={playlist.title}

--- a/src/components/video/VideoCard.tsx
+++ b/src/components/video/VideoCard.tsx
@@ -613,9 +613,12 @@ function VideoCardComponent({
     return (
       <div
         ref={cardRef}
-        className="group relative flex w-full flex-row items-center gap-4 rounded-xl px-1 py-2 transition-colors duration-200 ease-out hover:bg-chrome-neutral-800/40"
+        className={`group ${COLOR_WASH_HOST} flex w-full flex-row items-center gap-4 rounded-xl px-1 py-2`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
         onContextMenu={handleContextMenu}
       >
+        <ColorWash active={isHovered} color={dominantColor} alpha={0.2} spread="row" />
         {showDragHandle ? (
           <button
             type="button"
@@ -642,9 +645,11 @@ function VideoCardComponent({
         >
           {displayThumbnail ? (
             <img
+              ref={thumbnailRef}
               src={displayThumbnail}
               alt={displayTitle}
               className="h-full w-full object-cover"
+              crossOrigin="anonymous"
               loading="lazy"
               decoding="async"
               onLoad={handleThumbnailLoad}

--- a/src/components/video/VideoCard.tsx
+++ b/src/components/video/VideoCard.tsx
@@ -28,6 +28,8 @@ import { usePlayerStore } from '../../store/usePlayerStore';
 import { useDownloadStore } from '../../store/useDownloadStore';
 import { useDownloadsLibraryStore } from '../../store/useDownloadsLibraryStore';
 import { findDownloadedRecord, useIsDownloaded } from '../../lib/useDownloads';
+import { extractDominantColorFromImage, type Rgb } from '../../lib/useDominantColor';
+import { ColorWash, COLOR_WASH_HOST } from '../ui/ColorWash';
 
 export interface VideoCardProps {
   video: VideoSummary;
@@ -78,52 +80,6 @@ function getTitleClampStyle(maxLines: string | undefined): React.CSSProperties |
   };
 }
 
-// ─── Thumbnail Color Extraction ────────────────────────────────
-
-function extractDominantColor(img: HTMLImageElement): string | null {
-  try {
-    const canvas = document.createElement('canvas');
-    const ctx = canvas.getContext('2d', { willReadFrequently: true });
-    if (!ctx) return null;
-
-    const sampleSize = 16;
-    canvas.width = sampleSize;
-    canvas.height = sampleSize;
-    ctx.drawImage(img, 0, 0, sampleSize, sampleSize);
-
-    const imageData = ctx.getImageData(0, 0, sampleSize, sampleSize).data;
-
-    let totalR = 0, totalG = 0, totalB = 0, count = 0;
-    for (let i = 0; i < imageData.length; i += 4) {
-      const r = imageData[i] ?? 0;
-      const g = imageData[i + 1] ?? 0;
-      const b = imageData[i + 2] ?? 0;
-
-      const brightness = (r + g + b) / 3;
-      if (brightness < 30 || brightness > 230) continue;
-
-      const max = Math.max(r, g, b);
-      const min = Math.min(r, g, b);
-      if (max - min < 20) continue;
-
-      totalR += r;
-      totalG += g;
-      totalB += b;
-      count++;
-    }
-
-    if (count === 0) return null;
-
-    const avgR = Math.round(totalR / count);
-    const avgG = Math.round(totalG / count);
-    const avgB = Math.round(totalB / count);
-
-    return `${avgR}, ${avgG}, ${avgB}`;
-  } catch {
-    return null;
-  }
-}
-
 function VideoCardComponent({
   video,
   onPlay,
@@ -152,7 +108,7 @@ function VideoCardComponent({
   const [overriddenThumbnail, setOverriddenThumbnail] = useState<string | null>(null);
   const [showMenu, setShowMenu] = useState(false);
   const [menuAnchor, setMenuAnchor] = useState<MenuAnchor | null>(null);
-  const [dominantColor, setDominantColor] = useState<string | null>(null);
+  const [dominantColor, setDominantColor] = useState<Rgb | null>(null);
   const [isHovered, setIsHovered] = useState(false);
   const [isSavedToWatchLater, setIsSavedToWatchLater] = useState(false);
   const [thumbnailCandidateIndex, setThumbnailCandidateIndex] = useState(0);
@@ -244,7 +200,7 @@ function VideoCardComponent({
     if (IS_LINUX_RUNTIME) return;
     if (!dominantColor && thumbnailRef.current) {
       if (thumbnailRef.current.complete) {
-        const color = extractDominantColor(thumbnailRef.current);
+        const color = extractDominantColorFromImage(thumbnailRef.current);
         if (color) {
           setDominantColor(color);
         }
@@ -267,7 +223,7 @@ function VideoCardComponent({
     }
 
     if (!IS_LINUX_RUNTIME && isHovered && !dominantColor) {
-      const color = extractDominantColor(img);
+      const color = extractDominantColorFromImage(img);
       if (color) {
         setDominantColor(color);
       }
@@ -306,12 +262,6 @@ function VideoCardComponent({
   const handleThumbnailError = useCallback(() => {
     setThumbnailCandidateIndex((idx) => Math.min(idx + 1, Math.max(0, thumbnailCandidates.length - 1)));
   }, [thumbnailCandidates.length]);
-
-  const cardStyle: React.CSSProperties = isHovered
-    ? (dominantColor
-      ? { background: `rgba(${dominantColor}, 0.2)` }
-      : { background: 'color-mix(in srgb, var(--color-chrome-zinc-800) 50%, transparent)' })
-    : { background: 'transparent' };
 
   const handleSubscribeToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -583,12 +533,12 @@ function VideoCardComponent({
     return (
       <div
         ref={cardRef}
-        className="group relative flex w-full gap-2 rounded-xl p-1.5 -m-1.5 transition-colors duration-200 ease-out"
-        style={cardStyle}
+        className={`group ${COLOR_WASH_HOST} flex w-full gap-2 rounded-xl p-1.5 -m-1.5`}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
         onContextMenu={handleContextMenu}
       >
+        <ColorWash active={isHovered} color={dominantColor} alpha={0.2} spread="row" />
         <div
           className="relative aspect-video w-40 shrink-0 cursor-pointer overflow-hidden rounded-xl bg-surface-container"
           onClick={() => onPlay(video)}
@@ -755,13 +705,12 @@ function VideoCardComponent({
   return (
     <div
       ref={cardRef}
-      className="video-card flex flex-col gap-3 group relative rounded-xl p-1.5 -m-1.5 transition-colors duration-200 ease-out"
-      style={cardStyle}
+      className={`video-card flex flex-col gap-3 group ${COLOR_WASH_HOST} rounded-xl p-1.5 -m-1.5`}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onContextMenu={handleContextMenu}
     >
-
+      <ColorWash active={isHovered} color={dominantColor} alpha={0.2} />
       <div
         className="relative w-full aspect-video rounded-xl overflow-hidden bg-chrome-zinc-900 cursor-pointer"
         onClick={() => onPlay(video)}

--- a/src/components/video/VideoGrid.tsx
+++ b/src/components/video/VideoGrid.tsx
@@ -1,8 +1,8 @@
-import { Fragment, type ReactNode } from 'react';
+import { Fragment, useRef, type ReactNode } from 'react';
 import type { VideoSummary } from '../../types/video';
 import { VideoCard } from './VideoCard';
 import { SkeletonLoader } from '../ui/SkeletonLoader';
-import { useGridStyle } from '../../lib/useGridColumns';
+import { useGridStyle, useResolvedGridColumns } from '../../lib/useGridColumns';
 
 interface VideoGridProps {
   videos?: VideoSummary[];
@@ -11,7 +11,7 @@ interface VideoGridProps {
   onPlay: (video: VideoSummary) => void;
   onAddToQueue?: (video: VideoSummary) => void;
   onRemoveFromHistory?: (videoId: string) => void;
-  insertAfterIndex?: number;
+  /** Slotted in full-width directly under the first row of cards. */
   insertNode?: ReactNode;
   getVideoKey?: (video: VideoSummary, index: number) => string;
   variant?: "default" | "history";
@@ -40,18 +40,26 @@ export function VideoGrid({
   onPlay,
   onAddToQueue,
   onRemoveFromHistory,
-  insertAfterIndex,
   insertNode,
   getVideoKey,
   variant = "default",
   hideChannelAvatar,
 }: VideoGridProps) {
+  const gridRef = useRef<HTMLDivElement>(null);
   const gridStyle = useGridStyle();
+  const columns = useResolvedGridColumns(gridRef, gridStyle);
   const gridClass = "flow-grid gap-y-8 pb-8";
+
+  /*
+    The slot goes after the last card of the first row, whatever the resolved
+    column count is — a fixed index would leave the row's leftovers stranded on
+    a second row above the slot. -1 until the grid has been measured.
+  */
+  const insertAfterIndex = insertNode && columns > 0 ? Math.min(columns, videos.length) - 1 : -1;
 
   if (loading) {
     return (
-      <div className={gridClass} style={gridStyle}>
+      <div ref={gridRef} className={gridClass} style={gridStyle}>
         {Array.from({ length: skeletonCount }).map((_, i) => (
           <VideoCardSkeleton key={`skeleton-${i}`} />
         ))}
@@ -60,7 +68,7 @@ export function VideoGrid({
   }
 
   return (
-    <div className={gridClass} style={gridStyle}>
+    <div ref={gridRef} className={gridClass} style={gridStyle}>
       {videos.map((video, index) => (
         <Fragment key={getVideoKey ? getVideoKey(video, index) : `${video.id}-${index}`}>
           {/*
@@ -80,7 +88,7 @@ export function VideoGrid({
               hideChannelAvatar={hideChannelAvatar}
             />
           </div>
-          {insertNode && insertAfterIndex === index ? (
+          {insertAfterIndex === index ? (
             <div className="col-span-full">
               {insertNode}
             </div>

--- a/src/components/video/VideoGrid.tsx
+++ b/src/components/video/VideoGrid.tsx
@@ -66,10 +66,11 @@ export function VideoGrid({
           {/*
             content-visibility lets the browser skip layout/paint for offscreen
             cards — feeds can hold hundreds, and Linux composites on the CPU.
-            The p-1.5/-m-1.5 mirrors the card's hover bleed so the containment
-            paint clip lands exactly on the card's expanded edge.
+            The p-2/-m-2 nets to zero but widens the containment paint clip
+            past the card's own hover bleed, so the colour wash still has room
+            at the peak of its expansion — even at two columns on a wide window.
           */}
-          <div className="flow-grid-card p-1.5 -m-1.5">
+          <div className="flow-grid-card p-2 -m-2">
             <VideoCard
               video={video}
               onPlay={onPlay}

--- a/src/components/watch/CommentsSection.tsx
+++ b/src/components/watch/CommentsSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Loader2, ThumbsUp } from "lucide-react";
+import { Button } from "../ui/Button";
 import { useVideoComments } from "../../lib/useVideoComments";
 import { linkifyText } from "../../lib/linkify";
 import { formatCount } from "../../lib/utils";
@@ -161,10 +162,11 @@ export function CommentsSection({
 
           {thread.nextPageToken && (
             <div className="flex justify-center pt-4">
-              <button
+              <Button
+                variant="outline"
                 onClick={thread.loadMore}
                 disabled={thread.loadingMore}
-                className="flex items-center gap-2 rounded-full border border-chrome-neutral-800 bg-transparent px-6 py-2 text-sm font-semibold transition-colors hover:bg-surface-container disabled:opacity-50"
+                className="px-6 font-semibold"
               >
                 {thread.loadingMore ? (
                   <>
@@ -174,7 +176,7 @@ export function CommentsSection({
                 ) : (
                   getString("watch_load_more_comments")
                 )}
-              </button>
+              </Button>
             </div>
           )}
         </div>

--- a/src/components/watch/WatchLayout.tsx
+++ b/src/components/watch/WatchLayout.tsx
@@ -21,7 +21,7 @@ export function WatchLayout({ player, metadata, description, comments, sidebar }
             {comments}
           </div>
 
-          <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:col-start-3 lg:row-start-2 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto lg:p-2">
+          <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:col-start-3 lg:row-start-2 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto lg:p-2 hide-scrollbar">
             {sidebar}
           </div>
         </div>
@@ -39,7 +39,7 @@ export function WatchLayout({ player, metadata, description, comments, sidebar }
           {comments}
         </div>
 
-        <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto lg:p-2">
+        <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto lg:p-2 hide-scrollbar">
           {sidebar}
         </div>
       </div>

--- a/src/components/watch/WatchLayout.tsx
+++ b/src/components/watch/WatchLayout.tsx
@@ -1,6 +1,11 @@
 import { usePlayerStore } from "../../store/usePlayerStore";
 import type { WatchLayoutProps } from "./types";
 
+/*
+  The sidebar only scrolls from `lg` up, and that is also the only place it
+  clips: related cards bleed past their own box so their colour wash can grow.
+  `lg:p-2` keeps that bleed inside the scroller's paint box.
+*/
 export function WatchLayout({ player, metadata, description, comments, sidebar }: WatchLayoutProps) {
   const isTheaterMode = usePlayerStore((s) => s.isTheaterMode);
 
@@ -16,7 +21,7 @@ export function WatchLayout({ player, metadata, description, comments, sidebar }
             {comments}
           </div>
 
-          <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:col-start-3 lg:row-start-2 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto">
+          <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:col-start-3 lg:row-start-2 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto lg:p-2">
             {sidebar}
           </div>
         </div>
@@ -34,7 +39,7 @@ export function WatchLayout({ player, metadata, description, comments, sidebar }
           {comments}
         </div>
 
-        <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto">
+        <div className="flex w-full min-h-0 flex-col gap-5 overscroll-contain lg:sticky lg:top-6 lg:max-h-[calc(100vh-6.5rem)] lg:self-start lg:overflow-y-auto lg:p-2">
           {sidebar}
         </div>
       </div>

--- a/src/lib/accentColor.ts
+++ b/src/lib/accentColor.ts
@@ -1,0 +1,108 @@
+import type { Rgb } from './useDominantColor';
+
+/**
+ * Artwork colours cover the whole range, near-black and near-grey included, so
+ * painting an "on" state with one straight from the extractor often lands
+ * invisible against the player's dark chrome — which is exactly what a toggle
+ * cannot afford. These helpers keep the hue, the part that ties the control to
+ * the track, and lift everything else until the control is legible.
+ */
+
+const MIN_CHROMA = 18;
+const MIN_SATURATION = 0.5;
+const MIN_LIGHTNESS = 0.6;
+const MAX_LIGHTNESS = 0.9;
+const LIGHTNESS_STEP = 0.02;
+
+/** Contrast target against the chrome behind these controls (AA for icons). */
+const MIN_CONTRAST = 4.5;
+const CHROME: Rgb = { r: 24, g: 24, b: 27 };
+
+/** Used until artwork resolves, and whenever it yields nothing usable. */
+const FALLBACK = 'var(--color-primary)';
+
+function toHsl({ r, g, b }: Rgb): { h: number; s: number; l: number } {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const delta = max - min;
+  if (delta === 0) return { h: 0, s: 0, l };
+
+  const s = l > 0.5 ? delta / (2 - max - min) : delta / (max + min);
+  let h: number;
+  if (max === rn) h = ((gn - bn) / delta + (gn < bn ? 6 : 0)) / 6;
+  else if (max === gn) h = ((bn - rn) / delta + 2) / 6;
+  else h = ((rn - gn) / delta + 4) / 6;
+  return { h, s, l };
+}
+
+function channel(p: number, q: number, t: number): number {
+  const shifted = t < 0 ? t + 1 : t > 1 ? t - 1 : t;
+  if (shifted < 1 / 6) return p + (q - p) * 6 * shifted;
+  if (shifted < 1 / 2) return q;
+  if (shifted < 2 / 3) return p + (q - p) * (2 / 3 - shifted) * 6;
+  return p;
+}
+
+function toRgb(h: number, s: number, l: number): Rgb {
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  return {
+    r: Math.round(channel(p, q, h + 1 / 3) * 255),
+    g: Math.round(channel(p, q, h) * 255),
+    b: Math.round(channel(p, q, h - 1 / 3) * 255),
+  };
+}
+
+function relativeLuminance({ r, g, b }: Rgb): number {
+  const linear = (value: number) => {
+    const c = value / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+function contrastAgainstChrome(color: Rgb): number {
+  const a = relativeLuminance(color);
+  const b = relativeLuminance(CHROME);
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+/**
+ * Null for artwork with no usable hue, so callers fall back to the theme colour
+ * rather than showing a hue this function made up.
+ */
+function legible(color: Rgb): Rgb | null {
+  const chroma = Math.max(color.r, color.g, color.b) - Math.min(color.r, color.g, color.b);
+  if (chroma < MIN_CHROMA) return null;
+
+  const { h, s, l } = toHsl(color);
+
+  const saturation = Math.max(s, MIN_SATURATION);
+  // A fixed lightness floor is not enough on its own: blues carry far less
+  // luminance than yellows at the same L, so lift until it actually reads.
+  let lightness = Math.max(l, MIN_LIGHTNESS);
+  let candidate = toRgb(h, saturation, lightness);
+  while (lightness < MAX_LIGHTNESS && contrastAgainstChrome(candidate) < MIN_CONTRAST) {
+    lightness = Math.min(lightness + LIGHTNESS_STEP, MAX_LIGHTNESS);
+    candidate = toRgb(h, saturation, lightness);
+  }
+  return candidate;
+}
+
+/** Foreground colour for a control that is switched on, tinted by the artwork. */
+export function accentForeground(color: Rgb | null | undefined): string {
+  const readable = color ? legible(color) : null;
+  if (!readable) return FALLBACK;
+  return `rgb(${readable.r}, ${readable.g}, ${readable.b})`;
+}
+
+/** Tonal fill behind that control, so "on" reads without relying on hue alone. */
+export function accentSurface(color: Rgb | null | undefined, alpha = 0.22): string {
+  const readable = color ? legible(color) : null;
+  if (!readable) return `color-mix(in srgb, ${FALLBACK} ${Math.round(alpha * 100)}%, transparent)`;
+  return `rgba(${readable.r}, ${readable.g}, ${readable.b}, ${alpha})`;
+}

--- a/src/lib/i18n/strings.json
+++ b/src/lib/i18n/strings.json
@@ -540,6 +540,12 @@
   "settings_fullscreen_title_desc": "Show video title during fullscreen playback",
   "settings_adaptive_player": "Adaptive Player Size",
   "settings_adaptive_player_desc": "Scale viewport to match video aspect ratio",
+  "settings_music_player_background": "Music Player Background",
+  "settings_music_player_background_desc": "How the full-screen music player fills the space behind the artwork",
+  "settings_music_player_background_blur_gradient": "Blur + Gradient",
+  "settings_music_player_background_blur": "Blurred Artwork",
+  "settings_music_player_background_gradient": "Palette Gradient",
+  "settings_music_player_background_default": "Default Surface",
 
   "settings_group_layout": "Layout",
   "settings_grid_columns": "Grid Columns",

--- a/src/lib/i18n/strings.json
+++ b/src/lib/i18n/strings.json
@@ -350,6 +350,8 @@
   "theme_variant_description": "Every palette includes a light, dark, and AMOLED treatment.",
   "settings_expressive_sliders": "Expressive sliders",
   "settings_expressive_sliders_desc": "Use the Material 3 Expressive slider style for volume, the equaliser and the music seek bar",
+  "shelf_scroll_left": "Scroll left",
+  "shelf_scroll_right": "Scroll right",
   "theme_variant_light": "Light",
   "theme_variant_dark": "Dark",
   "theme_variant_amoled": "AMOLED",

--- a/src/lib/i18n/strings.json
+++ b/src/lib/i18n/strings.json
@@ -348,6 +348,8 @@
   "theme_page_description": "Choose a palette and tune how Flow looks in light, dark, and pure-black modes.",
   "theme_variant": "Theme variant",
   "theme_variant_description": "Every palette includes a light, dark, and AMOLED treatment.",
+  "settings_expressive_sliders": "Expressive sliders",
+  "settings_expressive_sliders_desc": "Use the Material 3 Expressive slider style for volume, the equaliser and the music seek bar",
   "theme_variant_light": "Light",
   "theme_variant_dark": "Dark",
   "theme_variant_amoled": "AMOLED",

--- a/src/lib/settings/schema.ts
+++ b/src/lib/settings/schema.ts
@@ -31,6 +31,7 @@ export interface SettingDefinition {
 export const SETTINGS = {
   THEME_ID: "theme_id",
   THEME_VARIANT: "theme_variant",
+  EXPRESSIVE_SLIDERS_ENABLED: "expressive_sliders_enabled",
   CUSTOM_THEMES: "custom_themes",
 
   AUTOPLAY_ENABLED: "autoplay_enabled",
@@ -221,6 +222,7 @@ const QUALITY_VALUES = ["Auto", "2160p", "1440p", "1080p", "720p", "480p", "360p
 export const SETTING_DEFINITIONS = [
   str(SETTINGS.THEME_ID, "appearance", "default", "wired"),
   str(SETTINGS.THEME_VARIANT, "appearance", "dark", "wired", ["light", "dark", "amoled"]),
+  bool(SETTINGS.EXPRESSIVE_SLIDERS_ENABLED, "appearance", true, "wired"),
   json(SETTINGS.CUSTOM_THEMES, "appearance", "[]", "wired"),
 
   bool(SETTINGS.AUTOPLAY_ENABLED, "player", true, "wired"),

--- a/src/lib/settings/schema.ts
+++ b/src/lib/settings/schema.ts
@@ -55,6 +55,7 @@ export const SETTINGS = {
   ADAPTIVE_PLAYER_SIZE_ENABLED: "adaptive_player_size_enabled",
   AUTO_PIP_ENABLED: "auto_pip_enabled",
   MANUAL_PIP_BUTTON_ENABLED: "manual_pip_button_enabled",
+  MUSIC_PLAYER_BACKGROUND: "music_player_background",
   LYRICS_PROVIDER_ORDER: "lyrics_provider_order",
   LYRICS_PROVIDER_ENABLED_STATES: "lyrics_provider_enabled_states",
 
@@ -244,6 +245,8 @@ export const SETTING_DEFINITIONS = [
   bool(SETTINGS.ADAPTIVE_PLAYER_SIZE_ENABLED, "player", true, "persisted-only"),
   bool(SETTINGS.AUTO_PIP_ENABLED, "player", true, "wired"),
   bool(SETTINGS.MANUAL_PIP_BUTTON_ENABLED, "player", true, "wired"),
+  str(SETTINGS.MUSIC_PLAYER_BACKGROUND, "player", "blur_gradient", "wired",
+    ["blur_gradient", "blur", "gradient", "default"]),
   str(SETTINGS.LYRICS_PROVIDER_ORDER, "player", "", "wired"),
   json(SETTINGS.LYRICS_PROVIDER_ENABLED_STATES, "player", "{}", "wired"),
 

--- a/src/lib/useExpressiveSliders.ts
+++ b/src/lib/useExpressiveSliders.ts
@@ -1,0 +1,8 @@
+import { SETTINGS } from './settings/schema';
+import { useBoolPref } from './usePreference';
+
+/** Off puts every converted slider back on the plain native control. */
+export function useExpressiveSliders(): boolean {
+  const [enabled] = useBoolPref(SETTINGS.EXPRESSIVE_SLIDERS_ENABLED, true);
+  return enabled;
+}

--- a/src/lib/useGridColumns.ts
+++ b/src/lib/useGridColumns.ts
@@ -1,4 +1,4 @@
-import { useMemo, type CSSProperties } from 'react';
+import { useLayoutEffect, useMemo, useState, type CSSProperties, type RefObject } from 'react';
 import { SETTINGS } from './settings/schema';
 import { useNumberPref } from './usePreference';
 
@@ -41,4 +41,45 @@ export function useGridStyle({ density = 'video', gapRem = 1 }: GridStyleOptions
       '--flow-grid-gap': `${gapRem}rem`,
     } as CSSProperties;
   }, [columns, density, gapRem]);
+}
+
+/**
+ * How many cards actually share a row right now.
+ *
+ * `.flow-grid` fills with `auto-fill`, so the user's column preference is only
+ * a ceiling — a narrow window sheds columns rather than shrinking cards. Only
+ * the resolved track list knows the real count, so anything that has to line up
+ * with a row boundary (a shelf slotted into the feed) has to measure it.
+ *
+ * Returns 0 until the first measurement lands.
+ */
+export function useResolvedGridColumns(
+  ref: RefObject<HTMLElement | null>,
+  style: CSSProperties,
+): number {
+  const [columns, setColumns] = useState(0);
+
+  // Layout effect, not a passive one: the count decides where a row break goes,
+  // and correcting that after paint would visibly reshuffle the feed.
+  useLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const measure = () => {
+      // A laid-out grid always reports used track sizes in px; anything else
+      // (`none`, an unresolved `repeat()`) means there is nothing to count yet.
+      const tracks = getComputedStyle(element).gridTemplateColumns;
+      const next = tracks.split(' ').filter((track) => track.endsWith('px')).length;
+      setColumns((previous) => (previous === next ? previous : next));
+    };
+
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+    // `style` carries the column preference, which changes the track count
+    // without changing the element's size — the observer alone would miss it.
+  }, [ref, style]);
+
+  return columns;
 }

--- a/src/lib/useHoverWashColor.ts
+++ b/src/lib/useHoverWashColor.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+import { useDominantColor, type Rgb } from './useDominantColor';
+
+export interface HoverWash {
+  isHovered: boolean;
+  /** Null until the artwork has been sampled — `ColorWash` shows a neutral tint. */
+  color: Rgb | null;
+  onMouseEnter: () => void;
+  onMouseLeave: () => void;
+}
+
+/**
+ * Hover state plus the artwork colour that fills a card's `ColorWash`.
+ *
+ * Sampling is deferred until the pointer first reaches the card: a feed holds
+ * hundreds of these, and decoding every thumbnail up front to tint a hover
+ * nobody may trigger is not worth it. Priming is one-way — dropping the source
+ * on mouse-leave would flip the colour back to neutral halfway through the
+ * fade-out — and repeat hovers land on `useDominantColor`'s per-URL cache.
+ *
+ * Pass the same URL the card renders so the sample reads a warm cache entry.
+ */
+export function useHoverWashColor(src: string | null | undefined): HoverWash {
+  const [isHovered, setIsHovered] = useState(false);
+  const [primed, setPrimed] = useState(false);
+  const color = useDominantColor(primed ? src : null);
+
+  const onMouseEnter = useCallback(() => {
+    setPrimed(true);
+    setIsHovered(true);
+  }, []);
+
+  const onMouseLeave = useCallback(() => setIsHovered(false), []);
+
+  return { isHovered, color, onMouseEnter, onMouseLeave };
+}

--- a/src/pages/Channel.tsx
+++ b/src/pages/Channel.tsx
@@ -4,6 +4,7 @@ import { Loader2, X } from "lucide-react";
 import { getChannelDetails, getChannelTab } from "../lib/api/youtube";
 import type { ChannelDetails, ChannelItem } from "../types/video";
 import { ChannelHero } from "../components/channel/ChannelHero";
+import { Button } from "../components/ui/Button";
 import { ChannelTabs, TabId } from "../components/channel/ChannelTabs";
 import { 
   ChannelShortsGrid, 
@@ -399,12 +400,9 @@ export const Channel: React.FC<ChannelProps> = ({ onPlay, onAddToQueue }) => {
           {getString("channel_unavailable_title")}
         </h2>
         <p className="max-w-md text-sm text-chrome-neutral-400">{getString("channel_unavailable_body")}</p>
-        <button
-          onClick={() => setHeroRetryToken((token) => token + 1)}
-          className="rounded-full bg-surface-container-high px-5 py-2 text-sm font-medium text-chrome-neutral-200 transition-colors hover:bg-surface-container-highest"
-        >
+        <Button variant="secondary" onClick={() => setHeroRetryToken((token) => token + 1)}>
           {getString("retry")}
-        </button>
+        </Button>
       </div>
     );
   }

--- a/src/pages/Donations.tsx
+++ b/src/pages/Donations.tsx
@@ -1,4 +1,5 @@
 import { Copy, Heart } from "lucide-react";
+import { Button } from "../components/ui/Button";
 import { getString } from "../lib/i18n/index";
 import { openExternal } from "../lib/openExternal";
 import { useUiStore } from "../store/useUiStore";
@@ -142,14 +143,10 @@ export default function Donations() {
               {getString("donations_patreon_desc")}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={() => void openExternal(PATREON_URL)}
-            className="inline-flex shrink-0 items-center gap-2 rounded-full bg-[var(--color-primary)] px-5 py-2.5 text-sm font-medium text-[var(--color-on-primary)] transition-opacity duration-200 ease-out hover:opacity-90"
-          >
+          <Button onClick={() => void openExternal(PATREON_URL)} className="shrink-0 px-5">
             <Heart className="h-4 w-4" />
             {getString("donations_patreon_button")}
-          </button>
+          </Button>
         </div>
       </section>
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -120,8 +120,8 @@ export const History: React.FC<HistoryProps> = ({ onPlay }) => {
   }, [visibleGroups, filter, expandedGroups, hasMore, loadingMore]);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-6 sm:px-6 lg:px-8">
-      <div className="mx-auto w-full shrink-0">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden py-6">
+      <div className="mx-auto w-full shrink-0 px-4 sm:px-6 lg:px-8">
         <header className="flex flex-col gap-5 border-b border-chrome-neutral-800 pb-6 lg:flex-row lg:items-end lg:justify-between">
           <div className="min-w-0">
             <h1 className="text-3xl font-bold tracking-tight text-chrome-neutral-100 lg:text-4xl">
@@ -166,31 +166,35 @@ export const History: React.FC<HistoryProps> = ({ onPlay }) => {
       </div>
 
       {loading ? (
-        <div className="flex flex-1 flex-col items-center justify-center py-32">
+        <div className="flex flex-1 flex-col items-center justify-center py-32 px-4 sm:px-6 lg:px-8">
           <Loader2 className="h-9 w-9 animate-spin text-[var(--color-primary)]" />
           <p className="mt-4 text-sm font-medium text-chrome-neutral-500">
             {getString("history_loading")}
           </p>
         </div>
       ) : history.length === 0 ? (
-        <div className="mx-auto mt-8 flex w-full flex-col items-center justify-center rounded-2xl border border-dashed border-chrome-neutral-800 bg-surface-container-low p-10 text-center">
-          <Clock className="mb-4 h-12 w-12 text-chrome-neutral-700" />
-          <h3 className="font-bold text-chrome-neutral-300">{getString("empty_watch_history")}</h3>
-          <p className="mt-1 max-w-sm text-sm text-chrome-neutral-500">
-            {getString("empty_watch_history_body")}
-          </p>
+        <div className="px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto mt-8 flex w-full flex-col items-center justify-center rounded-2xl border border-dashed border-chrome-neutral-800 bg-surface-container-low p-10 text-center">
+            <Clock className="mb-4 h-12 w-12 text-chrome-neutral-700" />
+            <h3 className="font-bold text-chrome-neutral-300">{getString("empty_watch_history")}</h3>
+            <p className="mt-1 max-w-sm text-sm text-chrome-neutral-500">
+              {getString("empty_watch_history_body")}
+            </p>
+          </div>
         </div>
       ) : visibleGroups.length === 0 ? (
-        <div className="mx-auto mt-8 w-full rounded-2xl border border-chrome-neutral-800 bg-surface-container-low p-8 text-center">
-          <p className="text-sm font-medium text-chrome-neutral-300">
-            No history results match your search.
-          </p>
+        <div className="px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto mt-8 w-full rounded-2xl border border-chrome-neutral-800 bg-surface-container-low p-8 text-center">
+            <p className="text-sm font-medium text-chrome-neutral-300">
+              No history results match your search.
+            </p>
+          </div>
         </div>
       ) : (
         <VList
           ref={listRef}
           onScroll={handleListScroll}
-          className="mx-auto mt-8 w-full flex-1 min-h-0"
+          className="mt-8 w-full flex-1 min-h-0 px-4 sm:px-6 lg:px-8"
         >
           {groupItems}
         </VList>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -66,14 +66,6 @@ const logHomeFeed = (stage: string, details: Record<string, unknown>) => {
   console.info(`[home-feed] ${stage}`, details);
 };
 
-const getHomeGridColumnCount = () => {
-  if (typeof window === "undefined") return 4;
-  if (window.innerWidth >= 1024) return 4;
-  if (window.innerWidth >= 768) return 3;
-  if (window.innerWidth >= 640) return 2;
-  return 1;
-};
-
 const buildContinueWatchingVideos = (history: WatchHistoryRecord[]): VideoSummary[] => {
   const hiddenIds = getHiddenContinueWatchingIds();
   const seenIds = new Set<string>();
@@ -169,7 +161,6 @@ export const Home: React.FC<HomeProps> = ({ onPlay, onAddToQueue }) => {
   const [, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [continueWatchingVideos, setContinueWatchingVideos] = useState<VideoSummary[]>([]);
-  const [gridColumnCount, setGridColumnCount] = useState(getHomeGridColumnCount);
   const [hasMoreDiscover, setHasMoreDiscover] = useState(true);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
   const requestSequenceRef = useRef(0);
@@ -1534,16 +1525,6 @@ export const Home: React.FC<HomeProps> = ({ onPlay, onAddToQueue }) => {
     videosRef.current = videos;
   }, [videos]);
 
-  useEffect(() => {
-    const handleResize = () => {
-      setGridColumnCount(getHomeGridColumnCount());
-    };
-
-    handleResize();
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
-  }, []);
-
   const refreshContinueWatching = useCallback(async () => {
     if (!continueWatchingEnabled) {
       setContinueWatchingVideos([]);
@@ -1706,9 +1687,6 @@ export const Home: React.FC<HomeProps> = ({ onPlay, onAddToQueue }) => {
     : [];
   const shouldInsertContinueShelf =
     homeFeedEnabled && !loading && visibleVideos.length > 0 && visibleContinueWatchingVideos.length > 0;
-  const continueShelfInsertAfterIndex = shouldInsertContinueShelf
-    ? Math.min(visibleVideos.length - 1, Math.max(0, gridColumnCount - 1))
-    : undefined;
 
   return (
     <div ref={scrollContainerRef} className="flex-1 overflow-y-auto px-8 py-6 space-y-6">
@@ -1735,7 +1713,6 @@ export const Home: React.FC<HomeProps> = ({ onPlay, onAddToQueue }) => {
             videos={visibleVideos}
             onPlay={handlePlayVideo}
             onAddToQueue={onAddToQueue}
-            insertAfterIndex={continueShelfInsertAfterIndex}
             insertNode={shouldInsertContinueShelf ? (
               <VideoShelf
                 title={getString("continue_watching_shelf_title")}

--- a/src/pages/ImportData.tsx
+++ b/src/pages/ImportData.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useRef } from "react";
-import { useNavigate } from "react-router-dom";
-import { ArrowLeft, Upload, Check, AlertCircle, FolderHeart, Heart, History, Tv, Loader2, Brain, Database, FileText, SlidersHorizontal } from "lucide-react";
+import { Upload, Check, AlertCircle, FolderHeart, Heart, History, Tv, Loader2, Brain, Database, FileText, SlidersHorizontal } from "lucide-react";
+import { SettingsGroup } from "../components/settings/SettingsGroup";
+import { SettingItem } from "../components/settings/SettingItem";
+import { ToggleSwitch } from "../components/ui/ToggleSwitch";
 import { unzipSync } from "fflate";
 import { getSetting, setSetting, addWatchRecordsBulk } from "../lib/api/db";
 import { useHistoryStore } from "../store/useHistoryStore";
@@ -45,7 +47,6 @@ async function refreshStoresAfterRestore() {
 }
 
 export const ImportData: React.FC = () => {
-  const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [importSubs, setImportSubs] = useState(true);
@@ -345,78 +346,57 @@ export const ImportData: React.FC = () => {
   ];
 
   return (
-    <div className="flex-1 overflow-y-auto px-8 py-6 space-y-6 pb-20 bg-[var(--color-background)]">
-      <div className="border-b border-[var(--color-outline-variant)] pb-4">
-        <div className="flex items-center gap-3">
-          <button onClick={() => navigate("/settings")} className="p-2 border border-chrome-neutral-800 hover:border-chrome-neutral-700 bg-surface-container-low hover:bg-surface-container rounded-xl text-chrome-neutral-400 hover:text-chrome-neutral-200 transition-colors duration-200 ease-out cursor-pointer">
-            <ArrowLeft size={16} />
-          </button>
-          <div>
-            <h1 className="text-3xl font-extrabold tracking-tight text-[var(--color-on-surface)]">{getString("import_title")}</h1>
-            <p className="text-xs text-[var(--color-on-surface-variant)] mt-1">{getString("import_subtitle")}</p>
-          </div>
-        </div>
-      </div>
+    <div className="mx-auto w-full max-w-[1600px] px-6 py-8 pb-20 md:px-8">
+      <header className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight text-chrome-neutral-100">{getString("import_title")}</h1>
+        <p className="mt-1 text-sm text-chrome-neutral-400">{getString("import_subtitle")}</p>
+      </header>
 
       <input type="file" ref={fileInputRef} onChange={handleFileChange} accept=".zip,.json,.xml,.opml,.csv,.txt,.html" className="hidden" />
 
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_400px] gap-8 items-start">
-        <div className="space-y-6 lg:max-h-[calc(100vh-180px)] lg:overflow-y-auto pr-2 scrollbar-none">
+      <div className="grid grid-cols-12 gap-4 md:gap-6">
+        <div className="col-span-12 space-y-6 lg:col-span-7">
           {importState === "idle" && (
-            <div className="bg-surface-container-low rounded-2xl border border-chrome-neutral-800 overflow-hidden">
-              <div className="px-5 py-3 border-b border-chrome-neutral-800/50">
-                <h3 className="text-xs uppercase tracking-widest text-chrome-neutral-500 font-semibold">{getString("import_data_to_import")}</h3>
-              </div>
-              <div className="divide-y divide-chrome-neutral-800/50">
-                {toggleItems.map((item) => (
-                  <div key={item.key} onClick={item.toggle} className="flex items-center justify-between px-5 py-3.5 hover:bg-surface-container transition-colors duration-200 ease-out cursor-pointer">
-                    <div className="flex items-center gap-3">
-                      <span className={item.checked ? "text-[var(--color-primary)]" : "text-chrome-neutral-500"}>{item.icon}</span>
-                      <div>
-                        <div className="text-sm font-medium text-chrome-neutral-200">{item.label}</div>
-                        <div className="text-xs text-chrome-neutral-400 mt-0.5">{item.desc}</div>
-                      </div>
-                    </div>
-                    <div className={`w-4 h-4 rounded flex items-center justify-center border transition-colors ${item.checked ? "border-[var(--color-primary)] bg-[var(--color-primary)] text-chrome-white" : "border-chrome-neutral-700 bg-surface-container-high"}`}>
-                      {item.checked && <Check size={10} strokeWidth={3} />}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <SettingsGroup title={getString("import_data_to_import")}>
+              {toggleItems.map((item) => (
+                <SettingItem key={item.key} icon={item.icon} title={item.label} description={item.desc}>
+                  <ToggleSwitch checked={item.checked} onChange={item.toggle} />
+                </SettingItem>
+              ))}
+            </SettingsGroup>
           )}
 
           <div
             onClick={handleCardClick}
-            className={`border border-dashed rounded-2xl flex flex-col items-center justify-center text-center transition-colors duration-200 ease-out cursor-pointer min-h-[280px] ${
-              ["reading", "parsing", "saving"].includes(importState) ? "border-chrome-neutral-800 bg-surface-container-low pointer-events-none"
+            className={`flex min-h-[280px] cursor-pointer flex-col items-center justify-center rounded-2xl border border-dashed text-center transition-colors duration-200 ease-out ${
+              ["reading", "parsing", "saving"].includes(importState) ? "pointer-events-none border-chrome-neutral-800 bg-surface-container-low"
               : importState === "success" ? "border-chrome-emerald-900 bg-surface-container-low hover:bg-surface-container"
               : importState === "error" ? "border-chrome-red-900 bg-surface-container-low hover:bg-surface-container"
-              : "border-chrome-neutral-700 bg-surface-container-low hover:bg-surface-container hover:border-chrome-neutral-600"
+              : "border-chrome-neutral-700 bg-surface-container-low hover:border-chrome-neutral-600 hover:bg-surface-container"
             }`}
           >
             {importState === "idle" && (
               <div className="space-y-3 p-8">
-                <div className="w-12 h-12 rounded-2xl bg-surface-container-high flex items-center justify-center border border-chrome-neutral-800 mx-auto">
-                  <Upload className="w-5 h-5 text-chrome-neutral-400" />
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border border-chrome-neutral-800 bg-surface-container-high">
+                  <Upload className="h-5 w-5 text-chrome-neutral-400" />
                 </div>
                 <div className="space-y-1">
                   <h4 className="text-base font-medium text-chrome-neutral-200">{getString("import_select_file")}</h4>
-                  <p className="text-xs text-chrome-neutral-400 max-w-sm mx-auto">{getString("import_supported_formats")}</p>
+                  <p className="mx-auto max-w-sm text-xs text-chrome-neutral-400">{getString("import_supported_formats")}</p>
                 </div>
               </div>
             )}
 
             {["reading", "parsing", "saving"].includes(importState) && (
               <div className="w-full max-w-md space-y-4 px-8 py-8">
-                <div className="flex justify-between items-center text-xs font-medium text-chrome-neutral-400">
+                <div className="flex items-center justify-between text-xs font-medium text-chrome-neutral-400">
                   <span>{statusMessage}</span>
                   <span className="font-mono text-chrome-neutral-300">{progress}%</span>
                 </div>
-                <div className="w-full h-1 bg-surface-container-high rounded-full overflow-hidden">
+                <div className="h-1 w-full overflow-hidden rounded-full bg-surface-container-high">
                   <div className="h-full bg-[var(--color-primary)] transition-all duration-300 ease-out" style={{ width: `${progress}%` }} />
                 </div>
-                <div className="flex items-center justify-center gap-2 text-chrome-neutral-500 text-xs">
+                <div className="flex items-center justify-center gap-2 text-xs text-chrome-neutral-500">
                   <Loader2 size={12} className="animate-spin" />
                   {getString("import_processing")}
                 </div>
@@ -425,17 +405,17 @@ export const ImportData: React.FC = () => {
 
             {importState === "success" && (
               <div className="space-y-3 p-8">
-                <div className="w-12 h-12 rounded-2xl bg-surface-container-high flex items-center justify-center border border-chrome-emerald-900 mx-auto">
-                  <Check className="w-5 h-5 text-chrome-emerald-500" />
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border border-chrome-emerald-900 bg-surface-container-high">
+                  <Check className="h-5 w-5 text-chrome-emerald-500" />
                 </div>
                 <h4 className="text-base font-medium text-chrome-neutral-200">{getString("import_complete")}</h4>
-                <div className="text-xs text-chrome-neutral-400 max-w-xs mx-auto space-y-1">
-                  {subsCount > 0 && <div className="flex justify-between bg-surface-container-high px-3 py-2 rounded-lg"><span>{getString("import_subscriptions")}</span><span className="font-mono text-chrome-neutral-200">{subsCount}</span></div>}
-                  {playlistsCount > 0 && <div className="flex justify-between bg-surface-container-high px-3 py-2 rounded-lg"><span>{getString("import_playlists")}</span><span className="font-mono text-chrome-neutral-200">{playlistsCount}</span></div>}
-                  {historyCount > 0 && <div className="flex justify-between bg-surface-container-high px-3 py-2 rounded-lg"><span>{getString("import_watch_history")}</span><span className="font-mono text-chrome-neutral-200">{historyCount}</span></div>}
-                  {likesCount > 0 && <div className="flex justify-between bg-surface-container-high px-3 py-2 rounded-lg"><span>{getString("import_likes")}</span><span className="font-mono text-chrome-neutral-200">{likesCount}</span></div>}
-                  {settingsCount > 0 && <div className="flex justify-between bg-surface-container-high px-3 py-2 rounded-lg"><span>{getString("import_settings")}</span><span className="font-mono text-chrome-neutral-200">{settingsCount}</span></div>}
-                  {neuroCount > 0 && <div className="flex justify-between bg-surface-container-high px-3 py-2 rounded-lg"><span>{getString("import_neuro_profile")}</span><span className="font-mono text-chrome-neutral-200">{getString("ok")}</span></div>}
+                <div className="mx-auto max-w-xs space-y-1 text-xs text-chrome-neutral-400">
+                  {subsCount > 0 && <div className="flex justify-between rounded-lg bg-surface-container-high px-3 py-2"><span>{getString("import_subscriptions")}</span><span className="font-mono text-chrome-neutral-200">{subsCount}</span></div>}
+                  {playlistsCount > 0 && <div className="flex justify-between rounded-lg bg-surface-container-high px-3 py-2"><span>{getString("import_playlists")}</span><span className="font-mono text-chrome-neutral-200">{playlistsCount}</span></div>}
+                  {historyCount > 0 && <div className="flex justify-between rounded-lg bg-surface-container-high px-3 py-2"><span>{getString("import_watch_history")}</span><span className="font-mono text-chrome-neutral-200">{historyCount}</span></div>}
+                  {likesCount > 0 && <div className="flex justify-between rounded-lg bg-surface-container-high px-3 py-2"><span>{getString("import_likes")}</span><span className="font-mono text-chrome-neutral-200">{likesCount}</span></div>}
+                  {settingsCount > 0 && <div className="flex justify-between rounded-lg bg-surface-container-high px-3 py-2"><span>{getString("import_settings")}</span><span className="font-mono text-chrome-neutral-200">{settingsCount}</span></div>}
+                  {neuroCount > 0 && <div className="flex justify-between rounded-lg bg-surface-container-high px-3 py-2"><span>{getString("import_neuro_profile")}</span><span className="font-mono text-chrome-neutral-200">{getString("ok")}</span></div>}
                 </div>
                 <p className="text-xs text-chrome-neutral-500">{getString("import_click_another")}</p>
               </div>
@@ -443,41 +423,32 @@ export const ImportData: React.FC = () => {
 
             {importState === "error" && (
               <div className="space-y-3 p-8">
-                <div className="w-12 h-12 rounded-2xl bg-surface-container-high flex items-center justify-center border border-chrome-red-900 mx-auto">
-                  <AlertCircle className="w-5 h-5 text-chrome-red-400" />
+                <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl border border-chrome-red-900 bg-surface-container-high">
+                  <AlertCircle className="h-5 w-5 text-chrome-red-400" />
                 </div>
                 <h4 className="text-base font-medium text-chrome-red-400">{getString("import_failed")}</h4>
-                <p className="text-xs text-chrome-neutral-400 max-w-sm mx-auto">{errorMessage || getString("import_file_not_recognized")}</p>
+                <p className="mx-auto max-w-sm text-xs text-chrome-neutral-400">{errorMessage || getString("import_file_not_recognized")}</p>
                 <p className="text-xs text-chrome-neutral-500">{getString("import_try_another")}</p>
               </div>
             )}
           </div>
         </div>
 
-        <div className="lg:sticky lg:top-24 space-y-6">
-          <div className="bg-surface-container-low rounded-2xl border border-chrome-neutral-800 overflow-hidden">
-            <div className="px-5 py-3 border-b border-chrome-neutral-800/50">
-              <h3 className="text-xs uppercase tracking-widest text-chrome-neutral-500 font-semibold">{getString("import_supported_formats_title")}</h3>
-            </div>
-            <div className="divide-y divide-chrome-neutral-800/50">
-              {formatItems.map((f) => (
-                <div key={f.label} className="flex items-center gap-3 px-5 py-3">
-                  <FileText size={14} className="text-chrome-neutral-500 shrink-0" />
-                  <div className="min-w-0">
-                    <div className="text-sm font-medium text-chrome-neutral-200">{f.label}</div>
-                    <div className="text-xs text-chrome-neutral-500">{f.ext}</div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          </div>
+        <div className="col-span-12 space-y-6 lg:col-span-5">
+          <SettingsGroup title={getString("import_supported_formats_title")}>
+            {formatItems.map((format) => (
+              <SettingItem key={format.label} icon={<FileText size={16} />} title={format.label}>
+                <span className="font-mono text-xs text-chrome-neutral-500">{format.ext}</span>
+              </SettingItem>
+            ))}
+          </SettingsGroup>
 
-          <div className="bg-surface-container-low rounded-2xl border border-chrome-neutral-800 p-5">
-            <div className="flex items-center gap-2 mb-3">
+          <div className="rounded-2xl border border-chrome-neutral-800 bg-surface-container-low p-5">
+            <div className="mb-3 flex items-center gap-2">
               <Database size={14} className="text-chrome-neutral-400" />
-              <h4 className="text-xs uppercase tracking-widest text-chrome-neutral-500 font-semibold">{getString("import_flowneuro_card_title")}</h4>
+              <h4 className="text-xs font-semibold uppercase tracking-widest text-chrome-neutral-500">{getString("import_flowneuro_card_title")}</h4>
             </div>
-            <p className="text-xs text-chrome-neutral-400 leading-relaxed">
+            <p className="text-xs leading-relaxed text-chrome-neutral-400">
               {getString("import_flowneuro_card_body")}
             </p>
           </div>

--- a/src/pages/Sync.tsx
+++ b/src/pages/Sync.tsx
@@ -15,6 +15,7 @@ import {
   X,
 } from "lucide-react";
 
+import { Button } from "../components/ui/Button";
 import { ToggleSwitch } from "../components/ui/ToggleSwitch";
 import { useSyncStore } from "../store/useSyncStore";
 import { SYNC_COLLECTIONS, type ManifestInfo, type StatInfo } from "../lib/api/sync";
@@ -386,13 +387,9 @@ function PairingState() {
       </p>
       <p className="mt-1 max-w-xs text-xs text-chrome-neutral-600">{getString("sync_host_address_hint")}</p>
 
-      <button
-        type="button"
-        onClick={() => void cancel()}
-        className="mt-10 flex items-center gap-2 rounded-full bg-surface-container-high px-6 py-2 text-sm font-medium text-chrome-neutral-200 transition-colors hover:bg-surface-container-highest"
-      >
+      <Button variant="secondary" onClick={() => void cancel()} className="mt-10 px-6">
         <X className="h-4 w-4" /> {getString("sync_cancel")}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -514,13 +511,9 @@ function MessageScreen({ icon, title, message }: { icon: React.ReactNode; title:
       {icon}
       <h2 className="text-base font-medium text-chrome-neutral-100">{title}</h2>
       {message && <p className="text-sm text-chrome-neutral-400">{message}</p>}
-      <button
-        type="button"
-        onClick={() => void reset()}
-        className="flex items-center gap-2 rounded-full bg-surface-container-high px-6 py-2.5 text-sm font-medium text-chrome-neutral-200 transition-colors hover:bg-surface-container-highest"
-      >
+      <Button variant="secondary" onClick={() => void reset()} className="px-6">
         <RotateCcw className="h-4 w-4" /> {getString("sync_start_over")}
-      </button>
+      </Button>
     </CenteredCard>
   );
 }

--- a/src/pages/music/ArtistPage.tsx
+++ b/src/pages/music/ArtistPage.tsx
@@ -1,8 +1,8 @@
-import { useState, type ButtonHTMLAttributes } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AlertTriangle, Check, ChevronRight, Music2, Play, Plus } from 'lucide-react';
 
-import { Button } from '../../components/ui/Button';
+import { Button, type ButtonProps } from '../../components/ui/Button';
 import { AlbumTrackRow } from '../../components/music/AlbumTrackRow';
 import { ArtistSkeleton } from '../../components/music/ArtistSkeleton';
 import { MusicItemCard } from '../../components/music/MusicItemCard';
@@ -43,19 +43,19 @@ function ArtistActionButton({
   children,
   className,
   ...props
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: ButtonProps) {
   return (
-    <button
-      type="button"
+    <Button
+      size="lg"
       className={cx(
-        'inline-flex h-12 items-center justify-center gap-2 rounded-full px-6 text-sm font-semibold transition-colors duration-200 ease-out disabled:pointer-events-none disabled:opacity-50',
+        'text-sm font-semibold',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-primary)]',
         className,
       )}
       {...props}
     >
       {children}
-    </button>
+    </Button>
   );
 }
 

--- a/src/pages/music/MusicHome.tsx
+++ b/src/pages/music/MusicHome.tsx
@@ -192,7 +192,7 @@ export default function MusicHome() {
             <h2 className="mb-3 px-1 text-xl font-bold tracking-tight text-chrome-neutral-100">
               {getString('music_quick_picks')}
             </h2>
-            <div className="grid auto-cols-[88%] grid-flow-col grid-rows-3 gap-x-4 gap-y-1 overflow-x-auto hide-scrollbar snap-x pb-4 sm:auto-cols-[46%] lg:auto-cols-[31%] xl:auto-cols-[23.5%]">
+            <div className="grid auto-cols-[88%] grid-flow-col grid-rows-3 gap-x-4 gap-y-1 overflow-x-auto hide-scrollbar snap-x px-3 -mx-3 pt-3 -mt-2 pb-4 sm:auto-cols-[46%] lg:auto-cols-[31%] xl:auto-cols-[23.5%]">
               {quickPicks.map((track) => (
                 <MusicItemCard
                   key={track.videoId ?? track.id}

--- a/src/pages/music/MusicHome.tsx
+++ b/src/pages/music/MusicHome.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, Loader2 } from 'lucide-react';
 import { CategoryChips } from '../../components/layout/CategoryChips';
 import { MusicItemCard } from '../../components/music/MusicItemCard';
 import { MusicShelf } from '../../components/music/MusicShelf';
+import { ShelfScroller } from '../../components/ui/ShelfScroller';
 import { Button } from '../../components/ui/Button';
 import { useMusicChipFilter, useMusicHome } from '../../lib/useMusicHome';
 import { useMusicPersonalization } from '../../lib/useMusicPersonalization';
@@ -189,7 +190,7 @@ export default function MusicHome() {
             <h2 className="mb-3 px-1 text-xl font-bold tracking-tight text-chrome-neutral-100">
               {getString('music_quick_picks')}
             </h2>
-            <div className="grid auto-cols-[88%] grid-flow-col grid-rows-3 gap-x-4 gap-y-1 overflow-x-auto hide-scrollbar snap-x px-3 -mx-3 pt-3 -mt-2 pb-4 sm:auto-cols-[46%] lg:auto-cols-[31%] xl:auto-cols-[23.5%]">
+            <ShelfScroller className="grid auto-cols-[88%] grid-flow-col grid-rows-3 gap-x-4 gap-y-1 snap-x px-3 -mx-3 pt-3 -mt-2 pb-4 sm:auto-cols-[46%] lg:auto-cols-[31%] xl:auto-cols-[23.5%]">
               {quickPicks.map((track) => (
                 <MusicItemCard
                   key={track.videoId ?? track.id}
@@ -200,7 +201,7 @@ export default function MusicHome() {
                   onMenu={() => addToQueue(track)}
                 />
               ))}
-            </div>
+            </ShelfScroller>
           </section>
         )}
 

--- a/src/pages/music/MusicHome.tsx
+++ b/src/pages/music/MusicHome.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, Loader2 } from 'lucide-react';
 import { CategoryChips } from '../../components/layout/CategoryChips';
 import { MusicItemCard } from '../../components/music/MusicItemCard';
 import { MusicShelf } from '../../components/music/MusicShelf';
+import { Button } from '../../components/ui/Button';
 import { useMusicChipFilter, useMusicHome } from '../../lib/useMusicHome';
 import { useMusicPersonalization } from '../../lib/useMusicPersonalization';
 import { useMusicPlayerStore } from '../../store/useMusicPlayerStore';
@@ -127,13 +128,9 @@ export default function MusicHome() {
         <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
           <AlertTriangle className="h-8 w-8 text-chrome-neutral-500" />
           <p className="text-sm text-chrome-neutral-400">{getString('music_error_generic')}</p>
-          <button
-            type="button"
-            onClick={() => void reload()}
-            className="rounded-full bg-surface-container-high px-4 py-2 text-sm font-medium text-chrome-neutral-200 transition-colors duration-200 ease-out hover:bg-surface-container-highest"
-          >
+          <Button variant="secondary" onClick={() => void reload()}>
             {getString('music_retry')}
-          </button>
+          </Button>
         </div>
       );
     }


### PR DESCRIPTION
## Summary

Material 3 Expressive pass over the shared UI primitives — cards, toggles, buttons,
sliders and shelves — plus the fixes that surfaced along the way: search suggestions
breaking on accented queries, the Home row splitting under the column setting, and
invisible shuffle/repeat state in the music player.

## Change type

- [x] Bug fix
- [x] Feature
## Summary

Material 3 Expressive passs — cards, toggles, buttons,
sliders and shelves — plus the fixes that surfaced along the way: search suggestions
breaking on accented querider the column setting, and
invisible shuffle/repeat state in the music player.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Refactor or maintenance
- [ ] Documentation
- [ ] Build, packaging, or CI

## Validation

- [x] `pnpm test` — 76 passed (11 files)
- [x] `pnpm build` — clean
- [x] `cargo fmt --manifes-all -- --check` — clean(after applying rustfmt)
- [x] `cargo clippy --manil --all-targets--all-features` — exit 0, no findings in changed files
- [ ] `cargo test --manifest-path src-tauri/Cargo.toml --all-targets --all-features` — **partial.** All 19 integration targets pass (151 tests, incl. the full `sync_*` suite). The `--lib` unit binary will not launch on this machine: `STATUS_ENTRYPOINT_NOT_FOUND` (0xc0000139) at process start, before any test runs.
Environmental Windows dynadds no dependencies andtouches no linking. Needs confirming on a working machine.
- [ ] I smoke-tested the affected desktop behavior. — **not done.**

## Screenshots or recordings

<!-- TODO: needed — this is almost entirely visible UI. -->

## Risk and compatibility

Frontend-only except one backend change: YouTube's suggest endpoint is now asked
for UTF-8 (`ie/oe=utf-8`) and goes through the shared HTTP client instead of building
one per keystroke. No schema, migration, permission or dependency changes.

Behaviour that changes without a setting: card hover, toggles, buttons and shelf
arrows. The new slider style can be reverted via Settings > Appearance > Expressive
sliders; video, Shorts and mini-player seek bars are untouched.

- [x] No new secrets, private data, telemetry, or broad Tauri permissions were introduced.
- [x] User-facing documentation was updated where needed. —
`changelog/v0.1.1-beta.txt
- [x] Dependency and lockfile changes are intentional and limited to this PR. — none
- [x] Breaking changes and upgrade steps are clearly documented. — none

Three things I changed from what you pasted, and why:

- Summary said "UI grid size customizations" — that's a different PR. The grid work here is one bug fix among ~13 commits.
- Two validation boxes untt (the --lib binary won'tlaunch here) or the smoke test (I never ran the app; Chrome's extension was down for the last several chaconfirm — the smoke testmatters most, since a lot of this is unverified visually.
- Bug fix ticked alongside Feature — the suggestions, grid row and shuffle/repeat items are genuine fixes.